### PR TITLE
1.2.1 Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # SDK Changelog
 
+## 1.2.1
+
+### @craftercms/ice
+- Added validation addAuthoringSupport require.js load event
+- `getICEAttributes`
+  - Auto calculates the label if not supplied based on the model param
+  - Validates parentModelId and path (model.craftercms.path) and throws console errors to help developers use the right values
+  - Adds a _secret_ second argument so that wrapping utilities can identify themselves and errors as the entry point of the error
+
+### @craftercms/utils
+- Renames misc/composeUrl param renamed for more accurate semantics
+
+### @craftercms/content
+- `parseDescriptor`
+  - Fixes issue  where repeat group items with inner node selectors weren't parsed
+  - Improvements in `getItem` service parsing and component detection algorithms for `getItem` and `getDescriptor`
+  - Adds ability to parse a `getTree` response into a flat content instance array
+  - Adds `getChildren` response recognition and throws with non-parsable responses
+
 ## 1.2.0
 
 ### @craftercms/classes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/ice/react/hooks.ts
+++ b/packages/ice/react/hooks.ts
@@ -42,7 +42,11 @@ export function useICE(config: ICEConfig): ICEPencilProps {
   });
 
   return {
-    props: getICEAttributes(config)
+    props: getICEAttributes(
+      config,
+      // @ts-ignore
+      '[Error @ useICE] '
+    )
   };
 
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -18,11 +18,11 @@
 import { LookupTable } from '@craftercms/models';
 
 export function composeUrl(baseUrl: string, endpoint: string): string;
-export function composeUrl(studioConfig: { baseUrl? }, endpoint: string): string;
-export function composeUrl(studioConfigOrBaseUrl: string | { baseUrl? }, endpoint: string): String {
-  const base = (typeof studioConfigOrBaseUrl === 'string')
-    ? studioConfigOrBaseUrl
-    : (studioConfigOrBaseUrl.baseUrl ? studioConfigOrBaseUrl.baseUrl + '/' : '');
+export function composeUrl(crafterConfig: { baseUrl? }, endpoint: string): string;
+export function composeUrl(crafterConfigOrBaseUrl: string | { baseUrl? }, endpoint: string): String {
+  const base = (typeof crafterConfigOrBaseUrl === 'string')
+    ? crafterConfigOrBaseUrl
+    : (crafterConfigOrBaseUrl.baseUrl ? crafterConfigOrBaseUrl.baseUrl + '/' : '');
 
   return `${base}${endpoint}`.replace(/([^:]\/)\/+/g, "$1");
 }


### PR DESCRIPTION
## @craftercms/ice
- Added validation addAuthoringSupport require.js load event
- `getICEAttributes`
  - Auto calculates the label if not supplied based on the model param
  - Validates parentModelId and path (model.craftercms.path) and throws console errors to help developers use the right values
  - Adds a _secret_ second argument so that wrapping utilities can identify themselves and errors as the entry point of the error

## @craftercms/utils
- Renames misc/composeUrl param renamed for more accurate semantics

## @craftercms/content
- `parseDescriptor`
  - Fixes issue  where repeat group items with inner node selectors weren't parsed
  - Improvements in `getItem` service parsing and component detection algorithms for `getItem` and `getDescriptor`
  - Adds ability to parse a `getTree` response into a flat content instance array
  - Adds `getChildren` response recognition and throws with non-parsable responses

## Note
These updates have been published to npm. These should flow straight through to master.
