### PR TITLE
1.2.3 Released

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.idea
-
 dist
 
 # Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # SDK Changelog
 
+## 1.2.3
+
+### @craftercms/ice
+- Add `package.json` to `react` folder for prettier import usage and module bundler support 
+
+### @craftercms/content
+- Improve robustness of `parseDescriptor` function
+
+### misc
+- Added docs to package readme files for plain html/js usage
+- Removed the `browser` field from `package.json` files so bundlers can make use of es6 modules and tree shaking
+
 ## 1.2.2
 
 ### @craftercms/ice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@
 ## 1.2.3
 
 ### @craftercms/ice
-- Add `package.json` to `react` folder for prettier import usage and module bundler support 
+- Add `package.json` to `react` folder for prettier import usage and module bundler support
 
 ### @craftercms/content
 - Improve robustness of `parseDescriptor` function
+- Adds `preParseSearchResults` function
 
 ### misc
 - Added docs to package readme files for plain html/js usage
 - Removed the `browser` field from `package.json` files so bundlers can make use of es6 modules and tree shaking
+- Add npm badge to README files
 
 ## 1.2.2
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,27 @@ Crafter CMS SDK for JavaScript in the browser and Node JS
 
 ## Project Structure
 
-- `packages` contains the different SDK packages and their respective sources (TypeScript for the most part)
+The `packages` directory contains the different SDK packages and their respective sources (TypeScript for the most part)
 
-## Building
+Please go into the distinct packages to see docs.
+
+- [classes](./packages/classes)
+- [content](./packages/content)
+- [ice](./packages/ice)
+- [models](./packages/models)
+- [redux](./packages/redux)
+- [search](./packages/search)
+- [utils](./packages/utils)
+
+## Building & Testing
+
+You don't ever need to do this unless you're interested in collaborating. See the [packages](./packages) you're interested on for usage instructions if you just want to consume the sdk.
+
+### Building
 
 - `yarn` will fetch all dependencies for development
 - `./build.sh` will use webpack to generate a production ES5 bundle under `dist` folder
 
-## Testing
+### Testing
 
 Run `yarn test` on each of the packages to execute all tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/sdk",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/classes/README.md
+++ b/packages/classes/README.md
@@ -6,19 +6,24 @@ This package contains useful classes for developing craftercms websites & applic
 
 ## Usage
 
+All of Crafter CMS packages can be used either via npm or in plain html/javascript via regular script imports.
+
 - Install module using `yarn` or `npm`
-  - Yarn: `yarn add @craftercms/classes`
-  - npm: `npm install @craftercms/classes`
+  - `yarn add @craftercms/classes` or
+  - `npm install @craftercms/classes`
 - Import and use the classes you need
 
-## Classes
----
+## Package Index
 
-## SDK Service
+The examples below assume usage in the style of using via npm. If you're using the bundles, 
+directly importing as a script in the browser, these functions will be under the global variable
+named `craftercms.classes` (i.e. `window.craftercms.classes`).
+
+### SDK Service
 
 `SDKService` Provides http get and post methods for Crafter services 
 
-## Examples
+#### Examples
 
 ```typescript
   import { httpGet } from '@craftercms/classes';

--- a/packages/classes/README.md
+++ b/packages/classes/README.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/classes?style=plastic)
+
 # @craftercms/classes
 
 This package contains useful classes for developing craftercms websites & applications.

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -106,6 +106,35 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
   });
 ```
 
+## preParseSearchResults
+Inspects and parses elasticsearch hits and pre-parses objects before they can be sent to parseDescriptor
+@see https://github.com/craftercms/craftercms/issues/4057 
+
+```js
+import { createQuery, search } from '@craftercms/search';
+import { parseDescriptor, preParseSearchResults } from '@craftercms/content';
+
+search(
+  createQuery('elasticsearch', {
+    query: {
+      bool: {
+        filter: [/*...*/]
+      }
+    }
+  }),
+  { baseUrl: 'http://localhost:8080', site: 'editorial' }
+).pipe(
+  map(({ hits, ...rest }) => ({
+    ...rest,
+    hits: hits.map(({ _source }) => parseDescriptor(
+      preParseSearchResults(_source)
+    ))
+  }))
+).subscribe((results) => {
+  // Do stuff with results...
+});
+```
+
 ## Get Item
 Get an Item from the content store.
 

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -1,8 +1,12 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/content?style=plastic)
+
 # @craftercms/content
 
 This package contains services for retrieving content and navigation using APIs offered by Crafter CMS.
 
 ## Usage
+
+### Via npm
 
 - Install module using `yarn` or `npm`
   - Yarn: `yarn add @craftercms/content`
@@ -10,24 +14,62 @@ This package contains services for retrieving content and navigation using APIs 
 - Import and use the service(s) you need
 - You may pre-configure content services to a certain configuration and then you may omit the config param on subsequent calls
 
-    ```typescript
-      import { Item } from '@craftercms/models';
-      import { getItem } from '@craftercms/content';
-      import { crafterConf } from '@craftercms/classes';
-    
-      // Configure crafter services "globally". Your config will be cached. 
-      // All content services use the specified configuration on subsequent calls.
-      crafterConf.configure({
-        baseUrl: 'http://authoring.company.com',
-        site: 'editorial'
+```typescript
+  import { Item } from '@craftercms/models';
+  import { getItem } from '@craftercms/content';
+  import { crafterConf } from '@craftercms/classes';
+
+  // Configure crafter services "globally". Your config will be cached. 
+  // All content services use the specified configuration on subsequent calls.
+  crafterConf.configure({
+    baseUrl: 'http://authoring.company.com',
+    site: 'editorial'
+  });
+ 
+  // Second param "config" will use "http://authoring.company.com" as 
+  // crafter base url and "editorial" as the site to query
+  getItem('/site/website/index.xml').subscribe((item: Item) => {
+    console.log(item);
+  });
+```
+
+## Via html script imports
+
+- Download the bundle and import them in your page.
+- The bundle declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
+- The `content` package depends on `rxjs`, `@craftercms/utils`, `@craftercms/classes`; make sure to import those too before the `content` script.
+ 
+ **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
+ 
+ ### Vanilla html/js example
+ ```html
+<div id="myFeature"></div>
+<script src="https://unpkg.com/rxjs"></script>
+<script src="https://unpkg.com/@craftercms/utils"></script>
+<script src="https://unpkg.com/@craftercms/classes"></script>
+<script src="https://unpkg.com/@craftercms/content"></script>
+<script>
+  (function ({ content }, { operators }) {
+
+    content.getItem(
+      '/site/website/index.xml',
+      { baseUrl: 'http://localhost:8080', site: 'editorial' }
+    ).pipe(
+      operators.map(content.parseDescriptor)
+    ).subscribe((model) => {
+      const elem = document.querySelector('#myFeature');
+      Object.entries(model).forEach(([fieldId, value]) => {
+        if (fieldId !== 'craftercms') {
+          const el = document.createElement('div');
+          el.innerText = `${fieldId}: ${value}`;
+          elem.appendChild(el);
+        }
       });
-     
-      // Second param "config" will use "http://authoring.company.com" as 
-      // crafter base url and "editorial" as the site to query
-      getItem('/site/website/index.xml').subscribe((item: Item) => {
-        console.log(item);
-      });
-    ```
+    });
+
+  })(craftercms, rxjs);
+</script>
+```
 
 ## parseDescriptor
 Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts) or a GraphQL response into a [Content Instance](../models/src/ContentInstance.ts). It could also be a collection of any of these types.

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -6,42 +6,24 @@ This package contains services for retrieving content and navigation using APIs 
 
 ## Usage
 
+All of Crafter CMS packages can be used either via npm or in plain html/javascript via regular script imports.
+
 ### Via npm
 
 - Install module using `yarn` or `npm`
   - Yarn: `yarn add @craftercms/content`
   - npm: `npm install @craftercms/content`
 - Import and use the service(s) you need
-- You may pre-configure content services to a certain configuration and then you may omit the config param on subsequent calls
 
-```typescript
-  import { Item } from '@craftercms/models';
-  import { getItem } from '@craftercms/content';
-  import { crafterConf } from '@craftercms/classes';
-
-  // Configure crafter services "globally". Your config will be cached. 
-  // All content services use the specified configuration on subsequent calls.
-  crafterConf.configure({
-    baseUrl: 'http://authoring.company.com',
-    site: 'editorial'
-  });
- 
-  // Second param "config" will use "http://authoring.company.com" as 
-  // crafter base url and "editorial" as the site to query
-  getItem('/site/website/index.xml').subscribe((item: Item) => {
-    console.log(item);
-  });
-```
-
-## Via html script imports
+### Via html script imports
 
 - Download the bundle and import them in your page.
 - The bundle declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
 - The `content` package depends on `rxjs`, `@craftercms/utils`, `@craftercms/classes`; make sure to import those too before the `content` script.
  
- **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
+**Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
  
- ### Vanilla html/js example
+#### Vanilla html/js example
  ```html
 <div id="myFeature"></div>
 <script src="https://unpkg.com/rxjs"></script>
@@ -71,7 +53,35 @@ This package contains services for retrieving content and navigation using APIs 
 </script>
 ```
 
-## parseDescriptor
+### Service pre-configuration
+You may pre-configure content services to a certain configuration to then you may omit the config param on subsequent calls to services
+
+```typescript
+  import { Item } from '@craftercms/models';
+  import { getItem } from '@craftercms/content';
+  import { crafterConf } from '@craftercms/classes';
+
+  // Configure crafter services "globally". Your config will be cached. 
+  // All content services use the specified configuration on subsequent calls.
+  crafterConf.configure({
+    baseUrl: 'http://authoring.company.com',
+    site: 'editorial'
+  });
+ 
+  // Second param "config" will use "http://authoring.company.com" as 
+  // crafter base url and "editorial" as the site to query
+  getItem('/site/website/index.xml').subscribe((item: Item) => {
+    console.log(item);
+  });
+```
+
+## Package Index
+
+The examples below assume usage in the style of using via npm. If you're using the bundles, 
+directly importing as a script in the browser, these functions will be under the global variable
+named `craftercms.content` (i.e. `window.craftercms.content`).
+
+### parseDescriptor
 Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts) or a GraphQL response into a [Content Instance](../models/src/ContentInstance.ts). It could also be a collection of any of these types.
 
 `parseDescriptor(response: Descriptor | Item | GraphQLResponse | Descriptor[] | Item[] | GraphQLResponse)`
@@ -80,11 +90,11 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 | ------------- |:--------------:|
 | response      | The response of a getItem, getDescriptor or GraphQL fetch call |
 
-### Returns
+#### Returns
 
 [ContentInstance](../models/src/ContentInstance.ts)
 
-### Examples
+#### Examples
 
 - If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem, getDescriptor or GraphQL responses.
 
@@ -106,7 +116,7 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
   });
 ```
 
-## preParseSearchResults
+### preParseSearchResults
 Inspects and parses elasticsearch hits and pre-parses objects before they can be sent to parseDescriptor
 @see https://github.com/craftercms/craftercms/issues/4057 
 
@@ -135,7 +145,7 @@ search(
 });
 ```
 
-## Get Item
+### Get Item
 Get an Item from the content store.
 
 `getItem(path: string, config?: CrafterConfig)`
@@ -145,11 +155,11 @@ Get an Item from the content store.
 | path          | The item’s path in the content store |
 | config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 [Item](../models/README.md#Item) - from the content store
 
-### Examples
+#### Examples
 
 - Get the index page from the site:
 
@@ -176,7 +186,7 @@ Get an Item from the content store.
   });
 ```
 
-## Get Descriptor
+### Get Descriptor
 Get the descriptor data of an Item in the content store.
 
 `getDescriptor(path: string, config?: CrafterConfig)` 
@@ -186,11 +196,11 @@ Get the descriptor data of an Item in the content store.
 | path          | The item’s path in the content store |
 | config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 [Descriptor](../models/README.md#Descriptor) - from the content store
 
-### Examples
+#### Examples
 
 - Get the index page from the site:
 
@@ -214,7 +224,7 @@ Get the descriptor data of an Item in the content store.
   });
 ```
 
-## Get Children
+### Get Children
 Get the list of Items directly under a folder in the content store.
 
 `getChildren(path: string, config?: CrafterConfig)` 
@@ -224,11 +234,11 @@ Get the list of Items directly under a folder in the content store.
 | path          | The folder’s path |
 | config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 [Item](../models/README.md#Item)[] - List of Items from the content store
 
-### Examples
+#### Examples
 
 - Get the children items under root folder from the site:
 
@@ -246,7 +256,7 @@ Get the list of Items directly under a folder in the content store.
   });
 ```
 
-## Get Tree
+### Get Tree
 Get the complete Item hierarchy under the specified folder in the content store.
 
 `getTree(path: string, depth: number, config: CrafterConfig)` 
@@ -257,11 +267,11 @@ Get the complete Item hierarchy under the specified folder in the content store.
 | depth         | Amount of levels to include. Optional. Default is `1` |
 | config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 [Item](../models/README.md#Item) - from the content store
 
-### Examples
+#### Examples
 
 - Get the items tree under root folder from the site:
 
@@ -281,7 +291,7 @@ Get the complete Item hierarchy under the specified folder in the content store.
   });
 ```
 
-## Get Navigation Tree
+### Get Navigation Tree
 Returns the navigation tree with the specified depth for the specified store URL.
 
 `getNavTree(path: string, depth: number, currentPageUrl: string, config: CrafterConfig)`
@@ -293,11 +303,11 @@ Returns the navigation tree with the specified depth for the specified store URL
 | currentPageUrl | The URL of the current page. Optional. Default is `''` |
 | config         | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 [NavigationItem](../models/README.md#NavigationItem) - from the content store
 
-### Examples
+#### Examples
 
 - Get the navigation tree of the root folder from the site (depth = 3):
 
@@ -315,7 +325,7 @@ Returns the navigation tree with the specified depth for the specified store URL
   });
 ```
 
-## Get Navigation Breadcrumb
+### Get Navigation Breadcrumb
 Returns the navigation items that form the breadcrumb for the specified store URL.
 
 `getNavBreadcrumb(path: string, root: string, config: CrafterConfig)`
@@ -326,11 +336,11 @@ Returns the navigation items that form the breadcrumb for the specified store UR
 | root           | the root URL, basically the starting point of the breadcrumb. Optional. Default is `''` |
 | config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 [NavigationItem](../models/README.md#NavigationItem)[] - List of NavigationItem from the content store
 
-### Examples
+#### Examples
 
 - Get the breadcrumb for the root folder from the site:
 
@@ -348,7 +358,7 @@ Returns the navigation items that form the breadcrumb for the specified store UR
   });
 ```
 
-## Transform
+### Transform
 Transforms a URL, based on the current site’s configuration. 
 
 - `transform(transformerName: string, path: string, config: CrafterConfig)` 
@@ -359,11 +369,11 @@ Transforms a URL, based on the current site’s configuration.
 | path             | URL that will be transformed |
 | config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
 
-### Returns
+#### Returns
 
 string - URL transformed according to transformer applied.
 
-### Examples
+#### Examples
 
 - Transform a store path into a render path
 

--- a/packages/ice/README.md
+++ b/packages/ice/README.md
@@ -2,7 +2,7 @@
 
 # @craftercms/ice
 
-Contains JavaScript utilities to use Crafter CMS' in-context editing in your Apps and Sites
+Contains JavaScript utilities to use Crafter CMS' in-context editing in your apps and sites
 
 **Note**: All methods of this package work with [Content Instance](../models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` and `preParseSearchResults` from `@craftercms/content` to obtain such data structure.
 

--- a/packages/ice/README.md
+++ b/packages/ice/README.md
@@ -1,8 +1,62 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/ice?style=plastic)
+
 # @craftercms/ice
 
 Contains JavaScript utilities to use Crafter CMS In Context Editing in your Apps and Sites
 
-**Note**: All methods of this package work with [Content Instance](../models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` from `@craftercms/content` to obtain such data structure. 
+**Note**: All methods of this package work with [Content Instance](../models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` from `@craftercms/content` to obtain such data structure.
+
+## Usage
+
+## Via npm
+
+- `yarn add @craftercms/ice` or `npm install @craftercms/ice`
+- `import` or `require` the functions you wish.
+
+The examples below assume usage via npm. 
+
+## Via html script imports
+
+- Download the bundle and import them in your page.
+- The bundles declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
+- The `ice` package depends on rxjs, make sure to import rxjs too before the `ice` script.
+ 
+ **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
+ 
+ ### Vanilla html/js example
+ ```html
+<div id="myFeature"></div>
+<script src="https://unpkg.com/rxjs"></script>
+<script src="https://unpkg.com/@craftercms/utils"></script>
+<script src="https://unpkg.com/@craftercms/classes"></script>
+<script src="https://unpkg.com/@craftercms/content"></script>
+<script src="https://unpkg.com/@craftercms/ice"></script>
+<script>
+  (function ({ content, ice }, { operators }) {
+
+    content.getItem(
+      '/site/website/index.xml',
+      { baseUrl: 'http://localhost:8080', site: 'editorial' }
+    ).pipe(
+      operators.map(content.parseDescriptor)
+    ).subscribe((model) => {
+      const attrs = ice.getICEAttributes({ model, parentModelId: '/site/website/index.xml' });
+      const elem = document.querySelector('#myFeature');
+      Object.entries(attrs).forEach(([attr, value]) => {
+        elem.setAttribute(attr, value);
+      });
+      Object.entries(model).forEach(([fieldId, value]) => {
+        if (fieldId !== 'craftercms') {
+          const el = document.createElement('div');
+          el.innerText = `${fieldId}: ${value}`;
+          elem.appendChild(el);
+        }
+      });
+    });
+
+  })(craftercms, rxjs);
+</script>
+```
 
 ## fetchIsAuthoring
 

--- a/packages/ice/README.md
+++ b/packages/ice/README.md
@@ -2,28 +2,28 @@
 
 # @craftercms/ice
 
-Contains JavaScript utilities to use Crafter CMS In Context Editing in your Apps and Sites
+Contains JavaScript utilities to use Crafter CMS' in-context editing in your Apps and Sites
 
-**Note**: All methods of this package work with [Content Instance](../models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` from `@craftercms/content` to obtain such data structure.
+**Note**: All methods of this package work with [Content Instance](../models/src/ContentInstance.ts) as data structure they understand (the model param). Use in conjunction with `parseDescriptor` and `preParseSearchResults` from `@craftercms/content` to obtain such data structure.
 
 ## Usage
 
-## Via npm
+All of Crafter CMS packages can be used either via npm or in plain html/javascript via regular script imports.
+
+### Via npm
 
 - `yarn add @craftercms/ice` or `npm install @craftercms/ice`
 - `import` or `require` the functions you wish.
 
-The examples below assume usage via npm. 
-
-## Via html script imports
+### Via html script imports
 
 - Download the bundle and import them in your page.
 - The bundles declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
 - The `ice` package depends on rxjs, make sure to import rxjs too before the `ice` script.
  
- **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
+**Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
  
- ### Vanilla html/js example
+#### Vanilla html/js example
  ```html
 <div id="myFeature"></div>
 <script src="https://unpkg.com/rxjs"></script>
@@ -58,11 +58,17 @@ The examples below assume usage via npm.
 </script>
 ```
 
-## fetchIsAuthoring
+## Package Index
+
+The examples below assume usage in the style of using via npm. If you're using the bundles, 
+directly importing as a script in the browser, these functions will be under the global variable
+named `craftercms.ice` (i.e. `window.craftercms.ice`).
+
+### fetchIsAuthoring
 
 Interrogates the current origin server to determine if the site/app is running in Crafter CMS authoring environment (Preview). Positive reply (`true`) means is authoring; assume you need to add pencils and import other authoring tools. False means is delivery and all authoring tools should be disabled.
 
-### Example
+#### Example
 
 ```typescript
 import { fetchIsAuthoring } from '@craftercms/ice';
@@ -72,11 +78,11 @@ fetchIsAuthoring().then((isAuthoring) => {
 });
 ```  
 
-## getIceAttributes
+### getIceAttributes
 
 Use this function to obtain the attributes that you need to add to your HTML element(s) to put pencils for In Context Editing.
 
-### Example
+#### Example
 
 ```typescript
   import { from, forkJoin } from 'rxjs';
@@ -101,11 +107,11 @@ Use this function to obtain the attributes that you need to add to your HTML ele
   });
 ```
 
-## getDropZoneAttributes
+### getDropZoneAttributes
 
 Use this function to obtain the attributes that you need to add to your HTML element(s) to mark them as an item selector drop zone.
 
-### Example
+#### Example
 
 ```typescript
   import { from, forkJoin } from 'rxjs';
@@ -141,11 +147,11 @@ Use this function to obtain the attributes that you need to add to your HTML ele
   });
 ```
 
-## addAuthoringSupport
+### addAuthoringSupport
 
 Use this method to include the necessary scripts to enable Crafter CMS authoring support (i.e. pencils, drag & drop, etc.) on your site/app. This function does not check whether you're in authoring or delivery. You should check that prior to invoking.
 
-### Example 
+#### Example 
 
 ```typescript jsx
 import React, { useEffect } from 'react';
@@ -168,11 +174,11 @@ function App() {
 }
 ```
 
-## repaintPencils
+### repaintPencils
 
 Re-renders all pencils
 
-### Example
+#### Example
 
 ```typescript jsx
 import { repaintPencils } from '@craftercms/ice';
@@ -194,6 +200,8 @@ React bindings for pencils and drop zones. Requires React 16.8.0 or above (hooks
 ### useICE
 
 Use this function to obtain the attributes that you need to add to your HTML element(s) to put pencils for In Context Editing.
+
+Make sure to use the parseDescriptor function from `@craftercms/content` as that's the structure these hooks understand.
 
 #### Example
 
@@ -236,6 +244,8 @@ Use this function to obtain the attributes that you need to add to your HTML ele
 
 Use this function to obtain the attributes that you need to add to your HTML element(s) to mark them as an item selector drop zone.
 
+Make sure to use the parseDescriptor function from `@craftercms/content` as that's the structure these hooks understand.
+
 ```typescript jsx
   import React, { useEffect, useState } from 'react';
   import { from, forkJoin } from 'rxjs';
@@ -262,7 +272,7 @@ Use this function to obtain the attributes that you need to add to your HTML ele
   function HomePage(props) {
     const { isAuthoring, model } = props;
     const { props: pencil } = useICE({ isAuthoring, model });
-    const { props: dz } = useDropZone({ isAuthoring, model, zoneName: 'features_o' });
+    const { props: dz } = useDropZone({ isAuthoring, model, fieldId: 'features_o' });
     return  (
       <div {...pencil}>
         <section className="features" {...dz}>

--- a/packages/ice/README.md
+++ b/packages/ice/README.md
@@ -202,7 +202,7 @@ Use this function to obtain the attributes that you need to add to your HTML ele
   import { from, forkJoin } from 'rxjs';
   import { map } from 'rxjs/operators';
   import { fetchIsAuthoring } from '@craftercms/ice';
-  import { useICE } from '@craftercms/ice/esm5/react';
+  import { useICE } from '@craftercms/ice/react';
   import { getItem, parseDescriptor } from '@craftercms/content';
   
   function App() {
@@ -241,7 +241,7 @@ Use this function to obtain the attributes that you need to add to your HTML ele
   import { from, forkJoin } from 'rxjs';
   import { map } from 'rxjs/operators';
   import { fetchIsAuthoring } from '@craftercms/ice';
-  import { useICE, useDropZone } from '@craftercms/ice/esm5/react';
+  import { useICE, useDropZone } from '@craftercms/ice/react';
   import { getItem, parseDescriptor } from '@craftercms/content';
   
   function App() {

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0-PLACEHOLDER",
   "description": "Crafter CMS in-context editing library",
   "main": "./bundles/ice.umd.js",
-  "browser": "./bundles/ice.umd.js",
   "module": "./esm5/ice.js",
   "es2015": "./esm2015/ice.js",
   "typings": "./ice.d.ts",

--- a/packages/ice/react/package.json
+++ b/packages/ice/react/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../bundles/react/index.umd.js",
+  "module": "../esm5/react/index.js",
+  "es2015": "../esm2015/react/index.js",
+  "typings": "./index.d.ts"
+}

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -2,11 +2,14 @@
 
 # @craftercms/models
 
-This package contains data model definitions of different structures of Crafter CMS. This interfaces are useful when developing in TypeScript.
+This package contains data model definitions of different structures of Crafter CMS. 
+These interfaces are useful when developing in TypeScript and for IDE auto-completion & suggestions.
 
 ## Usage
 
 - Install module using `yarn` or `npm`
-  - Yarn: `yarn add @craftercms/models`
-  - npm: `npm install @craftercms/models`
+  - `yarn add @craftercms/models` or
+  - `npm install @craftercms/models`
 - Import and use the models you need
+
+Most of our packages have `@craftercms/models` as a dependency and will pull it automatically when using npm.

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/models?style=plastic)
+
 # @craftercms/models
 
 This package contains data model definitions of different structures of Crafter CMS. This interfaces are useful when developing in TypeScript.

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -6,6 +6,8 @@ This package contains tools for integrating your application with Crafter Engine
 
 ## Usage
 
+All of Crafter CMS packages can be used either via npm or in plain html/javascript via regular script imports.
+
 - Install module using `yarn` or `npm`
   - Yarn: `yarn add @craftercms/redux`
   - npm: `npm install @craftercms/redux`
@@ -13,10 +15,13 @@ This package contains tools for integrating your application with Crafter Engine
 - Import and use the redux store provided by the library, or implement your own store.
 - Import and use the action(s) you need.
 
-## Utils
----
+The examples below assume usage in the style of using via npm. If you're using the bundles, 
+directly importing as a script in the browser, these functions will be under the global variable
+named `craftercms.redux` (i.e. `window.craftercms.redux`).
 
-## createReduxStore
+## Utilities
+
+### createReduxStore
 Creates a redux store with all the crafter-redux details attached. Optionally, custom app reducers and/or epics may be supplied to create the store as required by client application.
 
 `createReduxStore(config: Object)`
@@ -35,7 +40,7 @@ Default config:
   }
 ```
 
-### Example
+#### Example
 
 - Set the configuration for the redux store
 
@@ -67,7 +72,7 @@ Default config:
 
 ```
 
-## getState
+### getState
 Retrieves the current redux store state.
 
 `getState(store: Store)`
@@ -76,7 +81,7 @@ Retrieves the current redux store state.
 | ------------- |:--------------:|
 | store           | Redux store where the state is going to be retrieved from |
 
-### Example
+#### Example
 
 ```typescript
   import { getState } from '@craftercms/redux';
@@ -88,9 +93,8 @@ Retrieves the current redux store state.
 ```
 
 ## Action Creators
----
 
-## getItem
+### getItem
 Creates an action to get an Item from the content store.
 
 `getItem(itemUrl: string)`
@@ -100,7 +104,7 @@ Creates an action to get an Item from the content store.
 | 
 path           | The item’s path in the content store |
 
-### Example
+#### Example
 
 - Dispatch action to get the index page from the site into your store
 
@@ -112,7 +116,7 @@ path           | The item’s path in the content store |
   store.dispatch(getItem(itemUrl));
 ```
 
-## getDescriptor
+### getDescriptor
 Creates an action to get the descriptor data of an Item in the content store.
 
 `getDescriptor(path: string)`
@@ -121,7 +125,7 @@ Creates an action to get the descriptor data of an Item in the content store.
 | ------------- |:--------------:|
 | path           | The item’s path in the content store |
 
-### Example
+#### Example
 
 - Dispatch action to get the index page descriptor from the site into your store
 
@@ -133,7 +137,7 @@ Creates an action to get the descriptor data of an Item in the content store.
   store.dispatch(getDescriptor(itemUrl));
 ```
 
-## getChildren
+### getChildren
 Creates an action to get the list of Items directly under a folder into your store.
 
 `getChildren(path: string)`
@@ -142,7 +146,7 @@ Creates an action to get the list of Items directly under a folder into your sto
 | ------------- |:--------------:|
 | path           | The folder’s path |
 
-### Example
+#### Example
 
 - Dispatch action to get the children under a folder into your store
 
@@ -154,8 +158,7 @@ Creates an action to get the list of Items directly under a folder into your sto
   store.dispatch(getChildren(path));
 ```
 
-
-## getTree
+### getTree
 Creates an action to get the complete Item hierarchy under the specified folder in the content store.
 
 `getTree(path: string, depth: int)`
@@ -165,7 +168,7 @@ Creates an action to get the complete Item hierarchy under the specified folder 
 | path           | The folder’s path |
 | depth         | Amount of levels to include. Optional. Default is `1` |
 
-### Example
+#### Example
 
 - Dispatch action to get the items tree under the root folder into your store
 
@@ -177,7 +180,7 @@ Creates an action to get the complete Item hierarchy under the specified folder 
   store.dispatch(getTree(path, 2));
 ```
 
-## getNav
+### getNav
 Creates an action to return the navigation tree with the specified depth for the specified store URL.
 
 `getNav(path: string, depth: int, currentPageUrl: string)`
@@ -188,7 +191,7 @@ Creates an action to return the navigation tree with the specified depth for the
 | depth          | Amount of levels to include. Optional. Default is `1` |
 | currentPageUrl | The URL of the current page. Optional. Default is `''` |
 
-### Example
+#### Example
 
 - Dispatch action to get the navigation tree of the root folder from the site (depth = 2)
 
@@ -200,7 +203,7 @@ Creates an action to return the navigation tree with the specified depth for the
   store.dispatch(getNav(path, 2));
 ```
 
-## getNavBreadcrumb
+### getNavBreadcrumb
 Creates an action to return the navigation items that form the breadcrumb for the specified store URL.
 
 `getNavBreadcrumb(path: string, root: string)`
@@ -210,7 +213,7 @@ Creates an action to return the navigation items that form the breadcrumb for th
 | path            | The folder’s path |
 | root           | the root URL, basically the starting point of the breadcrumb. Optional. Default is `''` |
 
-### Example
+#### Example
 
 - Dispatch action to get the breadcrumb for the root folder from the site
 
@@ -222,7 +225,7 @@ Creates an action to return the navigation items that form the breadcrumb for th
   store.dispatch(getNavBreadcrumb(path));
 ```
 
-## search
+### search
 Creates an action to return the result for a given query.
 
 `search(query: Query)` 
@@ -231,7 +234,7 @@ Creates an action to return the result for a given query.
 | ------------- |:--------------:|
 | query         | The query object |
 
-### Example
+#### Example
 
 - Dispatch action to query for content
 
@@ -245,10 +248,6 @@ Creates an action to return the result for a given query.
 
   store.dispatch(search(query));
 ```
-
-
-
-
 
 Store state while loading item
 

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/redux?style=plastic)
+
 # @craftercms/redux
 
 This package contains tools for integrating your application with Crafter Engine and Crafter Search using Redux as the state container.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,13 +1,63 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/search?style=plastic)
+
 # @craftercms/search
 
 This package contains tools for integrating your application with Crafter Search.
 
 ## Usage
 
+## Via npm
+
 - Install module using `yarn` or `npm`
   - Yarn: `yarn add @craftercms/search`
   - npm: `npm install @craftercms/search`
 - Import and use the service(s) you need
+
+## Via html script imports
+
+- Download the bundle and import them in your page.
+- The bundles declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
+- The `search` package depends on `rxjs`, `@craftercms/utils`, `@craftercms/classes`; make sure to import those too before the `search` script.
+ 
+ **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
+ 
+ ### Vanilla html/js example
+ ```html
+<script src="https://unpkg.com/rxjs"></script>
+<script src="https://unpkg.com/@craftercms/utils"></script>
+<script src="https://unpkg.com/@craftercms/classes"></script>
+<script src="https://unpkg.com/@craftercms/content"></script>
+<script src="https://unpkg.com/@craftercms/search"></script>
+<script>
+  (function ({ search, content }, { operators }) {
+
+    const { map } = operators;
+    const { search, createQuery } = search;
+    const { parseDescriptor, preParseSearchResults } = content;
+
+    search(
+      createQuery('elasticsearch', {
+        query: {
+          bool: {
+            filter: [/*...*/]
+          }
+        }
+      }),
+      { baseUrl: 'http://localhost:8080', site: 'editorial' }
+    ).pipe(
+      map(({ hits, ...rest }) => ({
+        ...rest,
+        hits: hits.map(({ _source }) => parseDescriptor(
+          preParseSearchResults(_source)
+        ))
+      }))
+    ).subscribe((results) => {
+      // Do stuff with results...
+    });
+
+  })(craftercms, rxjs);
+</script>
+```
 
 ## Services
 ---

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -4,19 +4,61 @@
 
 Contains various utilities useful when developing with Crafter CMS
 
-## createLookupTable
+## Usage
+
+All of Crafter CMS packages can be used either via npm or in plain html/javascript via regular script imports.
+
+### Via npm
+
+- `yarn add @craftercms/utils` or `npm install @craftercms/utils`
+- `import` or `require` the functions you wish.
+
+### Via html script imports
+
+- Download the bundle and import them in your page.
+- The bundles declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
+- The `utils` package depends on rxjs, make sure to import rxjs too before the `utils` script.
+ 
+**Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
+ 
+#### Vanilla html/js example
+ ```html
+<div id="myFeature"></div>
+<script src="https://unpkg.com/rxjs"></script>
+<script src="https://unpkg.com/@craftercms/utils"></script>
+<script>
+  (function ({ utils }) {
+
+    const people = [
+      { id: 1, name: 'Mary' }
+    ]
+
+    const myLookup = utils.createLookupTable(people);
+    console.log(myLookup); // => { 1: { id: 1, name: 'Mary' } }
+
+  })(craftercms);
+</script>
+```
+
+## Package Index
+
+The examples below assume usage in the style of using via npm. If you're using the bundles, 
+directly importing as a script in the browser, these functions will be under the global variable
+named `craftercms.utils` (i.e. `window.craftercms.utils`).
+
+### createLookupTable
 Creates a lookup table based on an array of items (of a type) and the items id identifier.
 
-### Example
+#### Example
 
 - Create a lookup table of items:
 
 ```typescript
-  import { Item, LookupTable } from "@craftercms/models";
-  import { createLookupTable } from "@craftercms/utils";
+import { Item, LookupTable } from "@craftercms/models";
+import { createLookupTable } from "@craftercms/utils";
 
-  const items: Item[] = [/* ... */];
-  const itemsLookupTable: LookupTable<Item> = createLookupTable<Item>(items, 'url');
+const items: Item[] = [/* ... */];
+const itemsLookupTable: LookupTable<Item> = createLookupTable<Item>(items, 'url');
 ```
 
 The lookupTable will look like this:

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,4 @@
+![npm (scoped)](https://img.shields.io/npm/v/@craftercms/utils?style=plastic)
 
 # @craftercms/utils
 


### PR DESCRIPTION
### @craftercms/ice
- Add `package.json` to `react` folder for prettier import usage and module bundler support

### @craftercms/content
- Improve robustness of `parseDescriptor` function
- Adds `preParseSearchResults` function

### misc
- Added docs to package readme files for plain html/js usage
- Removed the `browser` field from `package.json` files so bundlers can make use of es6 modules and tree shaking
- Add npm badge to README files
- Added sample usage via vanilla html/js (no npm, transpiling, etc)

**Note**: This is released and should flow to master now.
