### PR TITLE
## 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # SDK Changelog
 
+## 2.0.2
+- Allow CORs
+  - Use `crafterConf.configure({ cors: true, ... })` to enable CORs mode.
+- Fix `fetchIsAuthoring` and `addAuthoringSupport` not retrieving for baseUrl from `crafterConf`.
+
 ## 2.0.1
 
 ### @craftercms/redux

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/classes/src/SDKService.ts
+++ b/packages/classes/src/SDKService.ts
@@ -16,15 +16,19 @@
 
 import { Observable } from 'rxjs';
 import { pluck } from 'rxjs/operators';
-import { ajax, AjaxResponse } from 'rxjs/ajax';
+import { ajax } from 'rxjs/ajax';
 import 'url-search-params-polyfill';
 import { LookupTable } from '@craftercms/models';
+import { crafterConf } from '@craftercms/classes';
 
 export function httpGet<T extends any = any>(requestURL: string, params: Object = {}, headers?: LookupTable): Observable<T> {
   const searchParams = new URLSearchParams(params as URLSearchParams);
-  return ajax.get(`${requestURL}?${searchParams.toString()}`, headers).pipe(
-    pluck('response')
-  );
+  return ajax({
+    url: `${requestURL}?${searchParams.toString()}`,
+    method: 'GET',
+    headers: headers,
+    crossDomain: crafterConf.getConfig().cors
+  }).pipe(pluck('response'));
 }
 
 export function httpPost<T extends any = any>(requestURL: string, body: Object = {}, headers?: LookupTable): Observable<T> {

--- a/packages/classes/src/SDKService.ts
+++ b/packages/classes/src/SDKService.ts
@@ -19,7 +19,7 @@ import { pluck } from 'rxjs/operators';
 import { ajax } from 'rxjs/ajax';
 import 'url-search-params-polyfill';
 import { LookupTable } from '@craftercms/models';
-import { crafterConf } from '@craftercms/classes';
+import { crafterConf } from './config';
 
 export function httpGet<T extends any = any>(requestURL: string, params: Object = {}, headers?: LookupTable): Observable<T> {
   const searchParams = new URLSearchParams(params as URLSearchParams);

--- a/packages/classes/src/config.ts
+++ b/packages/classes/src/config.ts
@@ -20,6 +20,7 @@ import { CrafterConfig } from '@craftercms/models';
 
 const DEFAULTS: CrafterConfig = {
   site: '',
+  cors: false,
   baseUrl: '',
   searchId: null,
   endpoints: {

--- a/packages/models/src/CrafterConfig.ts
+++ b/packages/models/src/CrafterConfig.ts
@@ -18,6 +18,7 @@ import { LookupTable } from '@craftercms/models';
 
 export interface CrafterConfig {
   site: string;
+  cors: boolean;
   baseUrl: string;
   searchId?: string;
   endpoints?: Endpoints;


### PR DESCRIPTION
- Allow CORs
  - Use `crafterConf.configure({ cors: true, ... })` to enable CORs mode.
- Fix `fetchIsAuthoring` and `addAuthoringSupport` not retrieving for baseUrl from `crafterConf`.

https://github.com/craftercms/craftercms/issues/5251