### PR TITLE
## 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.0.3
 
 ### All packages
-- Switching sdk versioning to follow CrafterCMS release version 
+- Switching SDK versioning to follow the CrafterCMS release version 
 
 ### @craftercms/content
 - Update `parseProps` (internally used by `parseDescriptor`) to include `orderDefault_f` (parsed as `orderInNav`) in the resulting ContentInstance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # SDK Changelog
 
+## 4.0.3
+
+### All packages
+- Switching sdk versioning to follow CrafterCMS release version 
+
+### @craftercms/content
+- Update `parseProps` (internally used by `parseDescriptor`) to include `orderDefault_f` (parsed as `orderInNav`) in the resulting ContentInstance.
+- Update `parseProps` and `parseDescriptor` options to receive `systemPropMap`, `ignoredProps`, `systemProps` to be used during parsing.
+  - Note: modifying these props will require you to _open_ the `ContentInstance` interface and extend it accordingly.
+- Improve `parseDescriptor` signatures definitions
+- Parse values of `orderInNav` and `disabled` to their target data types (float and boolean, respectively).
+- Export `extractContent` and `extractChildren` functions.
+- Export the default `systemPropMap`, `ignoredProps`, `systemProps`.
+
 ## 2.0.7
 
 ### @craftercms/content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/sdk",
-  "version": "2.0.7",
+  "version": "4.0.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/models/src/ContentInstance.ts
+++ b/packages/models/src/ContentInstance.ts
@@ -18,10 +18,12 @@ export interface ContentInstance {
   craftercms: {
     id: string
     path: string
-    label: string // Internal name
+    label: string // "Internal name"
     dateCreated: string
     dateModified: string
     contentTypeId: string
+    orderInNav?: number // For pages only
+    disabled: boolean
     sourceMap?: { [path: string]: string } // path: contentTypeId
   }
   [prop: string]: any

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "module": "es2015",
     "target": "es2015",
-    "lib": ["es2015", "es2017", "dom"],
+    "lib": ["dom", "es2019"],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -18,7 +18,7 @@
     },
     "rootDir": ".",
     "inlineSourceMap": true,
-    "lib": ["es5", "dom", "es2015", "es2017"],
+    "lib": ["dom", "es2019"],
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "target": "es5"


### PR DESCRIPTION
### All packages
- Switching sdk versioning to follow CrafterCMS release version

### @craftercms/content
- Update `parseProps` (internally used by `parseDescriptor`) to include `orderDefault_f` (parsed as `orderInNav`) in the resulting ContentInstance.
- Update `parseProps` and `parseDescriptor` options to receive `systemPropMap`, `ignoredProps`, `systemProps` to be used during parsing.
  - Note: modifying these props will require you to _open_ the `ContentInstance` interface and extend it accordingly.
- Improve `parseDescriptor` signatures definitions
- Parse values of `orderInNav` and `disabled` to their target data types (float and boolean, respectively).
- Export `extractContent` and `extractChildren` functions.
- Export the default `systemPropMap`, `ignoredProps`, `systemProps`.

