### PR TITLE
## 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # SDK Changelog
 
+## 4.1.0
+
+### @craftercms/classes
+- Update search API endpoint from `/api/1/site/search/search.json` to `api/1/site/elasticsearch/search`.
+
+### @craftercms/content
+- `urlTransform`, `getTree`, `getItem`, `getChildren` fix config argument to accept partial CrafterConfig
+- Update createQuery usage examples without SearchEngine parameter.
+
+### @craftercms/models
+- Update Endpoints interface `ELASTICSEARCH` property to `SEARCH`.
+
+### @craftercms/search
+- Remove ElasticQuery query implementation for ElasticSearch.
+- Use `Query` class instead of removed `ElasticQuery` class in `createQuery` function.
+- Update createQuery usage examples without SearchEngine parameter.
+
 ## 4.0.3
 
 ### All packages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/sdk",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/content/src/ContentStoreService.ts
+++ b/packages/content/src/ContentStoreService.ts
@@ -25,8 +25,8 @@ import { map } from 'rxjs/operators';
  * @param {string} path - The item’s path
  */
 export function getItem(path: string): Observable<Item>;
-export function getItem(path: string, config: CrafterConfig): Observable<Item>;
-export function getItem(path: string, config?: CrafterConfig): Observable<Item> {
+export function getItem(path: string, config: Partial<CrafterConfig>): Observable<Item>;
+export function getItem(path: string, config?: Partial<CrafterConfig>): Observable<Item> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_ITEM_URL);
   return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
@@ -68,8 +68,8 @@ export function getDescriptor(path: string, config?: Partial<GetDescriptorConfig
  * @param {string} path - the folder’s path
  */
 export function getChildren(path: string): Observable<Item[]>;
-export function getChildren(path: string, config: CrafterConfig): Observable<Item[]>;
-export function getChildren(path: string, config?: CrafterConfig): Observable<Item[]> {
+export function getChildren(path: string, config: Partial<CrafterConfig>): Observable<Item[]>;
+export function getChildren(path: string, config?: Partial<CrafterConfig>): Observable<Item[]> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_CHILDREN);
   return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
@@ -82,9 +82,9 @@ export function getChildren(path: string, config?: CrafterConfig): Observable<It
  */
 export function getTree(path: string): Observable<Item>;
 export function getTree(path: string, depth: number): Observable<Item>;
-export function getTree(path: string, depth: number, config: CrafterConfig): Observable<Item>;
-export function getTree(path: string, config: CrafterConfig): Observable<Item>;
-export function getTree(path: string, depth: number | CrafterConfig = 1, config?: CrafterConfig): Observable<Item> {
+export function getTree(path: string, depth: number, config: Partial<CrafterConfig>): Observable<Item>;
+export function getTree(path: string, config: Partial<CrafterConfig>): Observable<Item>;
+export function getTree(path: string, depth: number | Partial<CrafterConfig> = 1, config?: Partial<CrafterConfig>): Observable<Item> {
   if (typeof depth === 'object') {
     config = depth;
     depth = 1;

--- a/packages/content/src/UrlTransformationService.ts
+++ b/packages/content/src/UrlTransformationService.ts
@@ -38,8 +38,8 @@ export type UrlTransformers =
  * @param {string} url - URL that will be transformed
  */
 export function urlTransform(transformerName: UrlTransformers, url: string): Observable<string>;
-export function urlTransform(transformerName: UrlTransformers, url: string, config: CrafterConfig): Observable<string>;
-export function urlTransform(transformerName: UrlTransformers, url: string, config?: CrafterConfig): Observable<string> {
+export function urlTransform(transformerName: UrlTransformers, url: string, config: Partial<CrafterConfig>): Observable<string>;
+export function urlTransform(transformerName: UrlTransformers, url: string, config?: Partial<CrafterConfig>): Observable<string> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.TRANSFORM_URL);
   return SDKService.httpGet<string>(requestURL, {


### PR DESCRIPTION
### @craftercms/classes
- Update search API endpoint from `/api/1/site/search/search.json` to `api/1/site/elasticsearch/search`.

### @craftercms/content
- `urlTransform`, `getTree`, `getItem`, `getChildren` fix config argument to accept partial CrafterConfig
- Update createQuery usage examples without SearchEngine parameter.

### @craftercms/models
- Update Endpoints interface `ELASTICSEARCH` property to `SEARCH`.

### @craftercms/search
- Remove ElasticQuery query implementation for ElasticSearch.
- Use `Query` class instead of removed `ElasticQuery` class in `createQuery` function.
- Update createQuery usage examples without SearchEngine parameter.
