### PR TITLE
[8053] Remove deprecated getDescriptor API and update APIs in the js-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SDK Changelog
 
+## 5.0.0
+* Remove `getDescriptor` from `@craftercms/content` package and usages/references from `@craftercms/classes` and `@craftercms/redux`.
+
 ## 4.2.0
 * [@craftercms/redux]:
   * getTree action payload is now an object with `url` and `depth` properties.
@@ -48,7 +51,7 @@
 ## 4.0.3
 
 ### All packages
-- Switching SDK versioning to follow the CrafterCMS release version 
+- Switching SDK versioning to follow the CrafterCMS release version
 
 ### @craftercms/content
 - Update `parseProps` (internally used by `parseDescriptor`) to include `orderDefault_f` (parsed as `orderInNav`) in the resulting ContentInstance.
@@ -186,18 +189,18 @@
 ### @craftercms/ice
 - First published
 - Publishing generic Crafter CMS In Context Editing (ICE) attribute retrieval functions for pencils and drop zones (drag and drop)
-    - getIceAttributes, 
+    - getIceAttributes,
     - getDropZoneAttributes
-    - import/use in code by doing 
+    - import/use in code by doing
         - `import { getIceAttributes } from '@craftercms/ice';`
         - `import { getDropZoneAttributes } from '@craftercms/ice';`
 - Publishing generic util functions
-    - repaintPencils: Repaints/repositions Crafter CMS In Context Editing pencils 
+    - repaintPencils: Repaints/repositions Crafter CMS In Context Editing pencils
     - fetchIsAuthoring: Interrogates the current origin server to determine if the site/app is running in Crafter CMS authoring or delivery environments
     - addAuthoringSupport: Includes the necessary scripts to enable Crafter CMS authoring support
     - `import { repaintPencils, fetchIsAuthoring, addAuthoringSupport } from '@craftercms/ice';` as needed
 - Publishing React specific bindings via custom hooks:
-    - useICE, 
+    - useICE,
     - useDropZone
     - Import/use in code by doing
         - `import { useICE } from '@craftercms/ice/esm5/react';`

--- a/build.sh
+++ b/build.sh
@@ -331,16 +331,6 @@ addNgcPackageJson() {
   done
 }
 
-updateVersionReferences() {
-  NPM_DIR="$1"
-  (
-    echo "======      VERSION: Updating version references in ${NPM_DIR}"
-    cd ${NPM_DIR}
-    echo "======       EXECUTE: perl -p -i -e \"s/0\.0\.0\-PLACEHOLDER/${VERSION}/g\" $""(grep -ril 0\.0\.0\-PLACEHOLDER .)"
-    perl -p -i -e "s/0\.0\.0\-PLACEHOLDER/${VERSION}/g" $(grep -ril 0\.0\.0\-PLACEHOLDER .) </dev/null 2>/dev/null
-  )
-}
-
 #######################################
 # Drops the last entry of a path. Similar to normalizing a path such as
 # /parent/child/.. to /parent.
@@ -535,10 +525,6 @@ for PACKAGE in ${PACKAGES[@]}; do
     perl -p -i -e "s/\"NG_UPDATE_PACKAGE_GROUP\"/${NG_UPDATE_PACKAGE_GROUP}/g" ${NPM_DIR}/package.json </dev/null
 
     cp ${ROOT_DIR}/${PACKAGE}/README.md ${NPM_DIR}/
-  fi
-
-  if [[ -d ${NPM_DIR} ]]; then
-    updateVersionReferences ${NPM_DIR}
   fi
 
   travisFoldEnd "build package: ${PACKAGE}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/sdk",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/classes",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS utility classes for developing sites and applications",
   "main": "./bundles/classes.umd.js",
   "module": "./esm5/classes.js",
@@ -25,8 +25,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/models": "5.0.0",
+    "@craftercms/utils": "5.0.0",
     "query-string": "^9.1.0"
   },
   "devDependencies": {

--- a/packages/classes/src/config.ts
+++ b/packages/classes/src/config.ts
@@ -34,7 +34,8 @@ const DEFAULTS: CrafterConfig = {
   },
   fetchConfig: {},
   contentTypeRegistry: {},
-  headers: {}
+  headers: {},
+  flatten: false
 };
 
 class ConfigManager {

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -20,9 +20,9 @@ All of Crafter CMS packages can be used either via npm or in plain html/javascri
 - Download the bundle and import them in your page.
 - The bundle declare a global variable named `craftercms`. You can access all craftercms' packages and functions under this root.
 - The `content` package depends on `rxjs`, `@craftercms/utils`, `@craftercms/classes`; make sure to import those too before the `content` script.
- 
+
 **Tip**: Once you've imported the scripts, type `craftercms` on your browser's dev tools console to inspect the package(s)
- 
+
 #### Vanilla html/js example
  ```html
 <div id="myFeature"></div>
@@ -61,14 +61,14 @@ You may pre-configure content services to a certain configuration to then you ma
   import { getItem } from '@craftercms/content';
   import { crafterConf } from '@craftercms/classes';
 
-  // Configure crafter services "globally". Your config will be cached. 
+  // Configure crafter services "globally". Your config will be cached.
   // All content services use the specified configuration on subsequent calls.
   crafterConf.configure({
     baseUrl: 'http://authoring.company.com',
     site: 'editorial'
   });
- 
-  // Second param "config" will use "http://authoring.company.com" as 
+
+  // Second param "config" will use "http://authoring.company.com" as
   // crafter base url and "editorial" as the site to query
   getItem('/site/website/index.xml').subscribe((item: Item) => {
     console.log(item);
@@ -77,7 +77,7 @@ You may pre-configure content services to a certain configuration to then you ma
 
 ## Package Index
 
-The examples below assume usage in the style of using via npm. If you're using the bundles, 
+The examples below assume usage in the style of using via npm. If you're using the bundles,
 directly importing as a script in the browser, these functions will be under the global variable
 named `craftercms.content` (i.e. `window.craftercms.content`).
 
@@ -86,9 +86,9 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 
 `parseDescriptor(response: Descriptor | Item | GraphQLResponse | Descriptor[] | Item[] | GraphQLResponse)`
 
-| Parameters    |                |
-| ------------- |:--------------:|
-| response      | The response of a getItem, getDescriptor or GraphQL fetch call |
+| Parameters    |                                                 |
+| ------------- |:-----------------------------------------------:|
+| response      | The response of a getItem or GraphQL fetch call |
 
 #### Returns
 
@@ -96,13 +96,13 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 
 #### Examples
 
-- If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem, getDescriptor or GraphQL responses.
+- If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem or GraphQL responses.
 
 ```typescript
   import { map } from 'rxjs/operators';
   import { ContentInstance } from '@craftercms/models';
   import { getChildren, getItem, parseDescriptor } from '@craftercms/content';
-  
+
   getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
     map(parseDescriptor)
   ).subscribe((content: ContentInstance) => {
@@ -118,7 +118,7 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 
 ### preParseSearchResults
 Inspects and parses elasticsearch hits and pre-parses objects before they can be sent to parseDescriptor
-@see https://github.com/craftercms/craftercms/issues/4057 
+@see https://github.com/craftercms/craftercms/issues/4057
 
 ```js
 import { createQuery, search } from '@craftercms/search';
@@ -165,8 +165,8 @@ Get an Item from the content store.
 
 ```typescript
   import { Item } from '@craftercms/models';
-  import { getItem } from '@craftercms/content'; 
-  
+  import { getItem } from '@craftercms/content';
+
   getItem('/site/website/index.xml', { site: 'editorial' }).subscribe((item: Item) => {
     console.log(item);
   });
@@ -178,47 +178,9 @@ Get an Item from the content store.
   import { map } from 'rxjs/operators';
   import { ContentInstance } from '@craftercms/models';
   import { getItem, parseDescriptor } from '@craftercms/content';
-  
+
   getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
     map(parseDescriptor)
-  ).subscribe((content: ContentInstance) => {
-    console.log(content);
-  });
-```
-
-### Get Descriptor
-Get the descriptor data of an Item in the content store.
-
-`getDescriptor(path: string, config?: CrafterConfig)` 
-
-| Parameters    |                |
-| ------------- |:--------------:|
-| path          | The item’s path in the content store |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
-
-#### Returns
-
-[Descriptor](../models/README.md#Descriptor) - from the content store
-
-#### Examples
-
-- Get the index page from the site:
-
-```typescript
-  import { map } from 'rxjs/operators';
-  import { getDescriptor, parseDescriptor } from '@craftercms/content';
-  import { Descriptor, ContentInstance } from '@craftercms/models';
-
-  // Example 1: Supplying config inline, Descriptor response...
-  getDescriptor('/site/website/index.xml', { site: 'editorial' }).subscribe((descriptor: Descriptor) => {
-    console.log(descriptor);
-  });
-
-  // Example 2: 
-  // - Omit config (must have configured earlier @see Usage section above)
-  // - Parse the response
-  getDescriptor('/site/website/index.xml').pipe(
-    map(parseDescriptor) // Optional. Use for a cleaner parsed response.
   ).subscribe((content: ContentInstance) => {
     console.log(content);
   });
@@ -227,7 +189,7 @@ Get the descriptor data of an Item in the content store.
 ### Get Children
 Get the list of Items directly under a folder in the content store.
 
-`getChildren(path: string, config?: CrafterConfig)` 
+`getChildren(path: string, config?: CrafterConfig)`
 
 | Parameters    |                |
 | ------------- |:--------------:|
@@ -249,7 +211,7 @@ Get the list of Items directly under a folder in the content store.
   getChildren('/site/website', { site: 'editorial' }).subscribe((children) => {
     console.log(children);
   });
-  
+
   // Example 2: Omits the config param (must have been previously configured, see Usage section above)
   getChildren('/site/website').subscribe((children) => {
     console.log(children);
@@ -259,7 +221,7 @@ Get the list of Items directly under a folder in the content store.
 ### Get Tree
 Get the complete Item hierarchy under the specified folder in the content store.
 
-`getTree(path: string, depth: number, config: CrafterConfig)` 
+`getTree(path: string, depth: number, config: CrafterConfig)`
 
 | Parameters    |                |
 | ------------- |:--------------:|
@@ -359,9 +321,9 @@ Returns the navigation items that form the breadcrumb for the specified store UR
 ```
 
 ### Transform
-Transforms a URL, based on the current site’s configuration. 
+Transforms a URL, based on the current site’s configuration.
 
-- `transform(transformerName: string, path: string, config: CrafterConfig)` 
+- `transform(transformerName: string, path: string, config: CrafterConfig)`
 
 | Parameters      |                |
 | --------------- |:--------------:|
@@ -397,7 +359,7 @@ string - URL transformed according to transformer applied.
   import { transform } from '@craftercms/content';
 
   // Assuming that you already set the configuration (as explained above)
-  
+
   // Example 1: Config supplied inline
   transform('renderUrlToStoreUrl', '/technology', { site: 'editorial' }).subscribe((path) => {
     console.log(path); // "/site/website/technology/index.xml"

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/content",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS services for content and navigation retrieval",
   "main": "./bundles/content.umd.js",
   "module": "./esm5/content.js",
@@ -25,9 +25,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/classes": "0.0.0-PLACEHOLDER",
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/classes": "5.0.0",
+    "@craftercms/models": "5.0.0",
+    "@craftercms/utils": "5.0.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/packages/content/src/ContentStoreService.ts
+++ b/packages/content/src/ContentStoreService.ts
@@ -16,9 +16,8 @@
 
 import { Observable } from 'rxjs';
 import { crafterConf, SDKService } from '@craftercms/classes';
-import { CrafterConfig, Descriptor, Item } from '@craftercms/models';
+import { CrafterConfig, Item } from '@craftercms/models';
 import { composeUrl } from '@craftercms/utils';
-import { map } from 'rxjs/operators';
 
 /**
  * Returns an Item from the content store.
@@ -29,38 +28,7 @@ export function getItem(path: string, config: Partial<CrafterConfig>): Observabl
 export function getItem(path: string, config?: Partial<CrafterConfig>): Observable<Item> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_ITEM_URL);
-  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
-}
-
-export interface GetDescriptorConfig extends CrafterConfig {
-  flatten: boolean;
-}
-
-/**
- * Returns the descriptor data of an Item in the content store.
- * @param {string} path - The item’s path
- * @param {CrafterConfig & GetDescriptorConfig} config? - The config override options to use
- */
-export function getDescriptor(path: string): Observable<Descriptor>;
-export function getDescriptor(path: string, config: Partial<GetDescriptorConfig>): Observable<Descriptor>;
-export function getDescriptor(path: string, config?: Partial<GetDescriptorConfig>): Observable<Descriptor> {
-  let cfg = crafterConf.mix(config);
-  return SDKService.httpGet<Descriptor>(composeUrl(cfg, cfg.endpoints.GET_DESCRIPTOR), {
-    url: path,
-    crafterSite: cfg.site,
-    flatten: Boolean(config?.flatten)
-  }, cfg.headers).pipe(
-    // Manually introduce the path into the response as descriptor endpoint does not return it.
-    map((descriptor: Descriptor) => {
-      let prop = typeof descriptor.page === 'undefined' ? 'component' : 'page';
-      return {
-        [prop]: {
-          ...descriptor[prop],
-          localId: path
-        }
-      };
-    })
-  );
+  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site, flatten: Boolean(config?.flatten) }, config.headers);
 }
 
 /**
@@ -72,7 +40,7 @@ export function getChildren(path: string, config: Partial<CrafterConfig>): Obser
 export function getChildren(path: string, config?: Partial<CrafterConfig>): Observable<Item[]> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_CHILDREN);
-  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site, flatten: Boolean(config?.flatten) }, config.headers);
 }
 
 /**
@@ -91,12 +59,11 @@ export function getTree(path: string, depth: number | Partial<CrafterConfig> = 1
   }
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_TREE);
-  return SDKService.httpGet(requestURL, { url: path, depth, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(requestURL, { url: path, depth, crafterSite: config.site, flatten: Boolean(config?.flatten) }, config.headers);
 }
 
 export const ContentStoreService = {
   getItem,
-  getDescriptor,
   getChildren,
   getTree
 };

--- a/packages/content/src/utils.ts
+++ b/packages/content/src/utils.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import { ContentInstance, Descriptor, DescriptorResponse, Item } from '@craftercms/models';
+import { ContentInstance, type CrafterConfig, Descriptor, DescriptorResponse, Item } from '@craftercms/models';
 import { urlTransform } from './UrlTransformationService';
-import { getDescriptor, GetDescriptorConfig } from './ContentStoreService';
+import { getItem } from './ContentStoreService';
 import { map, switchMap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
@@ -92,7 +92,7 @@ export function parseDescriptor(
       '[parseDescriptor] Invalid descriptor supplied. Did you call ' +
       'parseDescriptor with a `getChildren` API response? The `getChildren` API ' +
       'response may contain certain items that are not parsable into ContentInstances. ' +
-      'Try a different API (getItem, getDescriptor or getTree) or filter out the metadata ' +
+      'Try a different API (getItem or getTree) or filter out the metadata ' +
       'items which descriptorDom property has a `page` or `component` property with the content item.'
     );
   }
@@ -210,32 +210,32 @@ export function parseFieldValue(propName: string, propValue: any): number | stri
 }
 
 export function fetchModelByPath(path: string): Observable<ContentInstance>;
-export function fetchModelByPath(path: string, options: Partial<GetDescriptorConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
+export function fetchModelByPath(path: string, options: Partial<CrafterConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
 export function fetchModelByPath(
   path: string,
-  options?: Partial<GetDescriptorConfig & ParseDescriptorOptions>
+  options?: Partial<CrafterConfig & ParseDescriptorOptions>
 ): Observable<ContentInstance> {
   let pdo = mixParseDescriptorOptions({ parseFieldValueTypes: true, ...options });
-  return getDescriptor(path, { flatten: true, ...options }).pipe(
-    map((descriptor) => parseDescriptor(descriptor, pdo))
+  return getItem(path, { flatten: true, ...options }).pipe(
+    map(({ descriptorDom }) => parseDescriptor(descriptorDom, pdo))
   );
 }
 
 export function fetchModelByUrl(webUrl: string): Observable<ContentInstance>;
-export function fetchModelByUrl(webUrl: string, options: Partial<GetDescriptorConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
+export function fetchModelByUrl(webUrl: string, options: Partial<CrafterConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
 export function fetchModelByUrl(
   webUrl: string,
-  options?: Partial<GetDescriptorConfig & ParseDescriptorOptions>
+  options?: Partial<CrafterConfig & ParseDescriptorOptions>
 ): Observable<ContentInstance> {
   let pdo = mixParseDescriptorOptions({ parseFieldValueTypes: true, ...options });
   return urlTransform('renderUrlToStoreUrl', webUrl).pipe(
-    switchMap((path) => getDescriptor(path as string, { flatten: true, ...options })),
-    map((descriptor) => parseDescriptor(descriptor, pdo))
+    switchMap((path) => getItem(path as string, { flatten: true, ...options })),
+    map(({ descriptorDom }) => parseDescriptor(descriptorDom, pdo))
   );
 }
 
 /**
- * Inspects the data for getItem or getDescriptor responses and returns the inner content object
+ * Inspects the data for getItem responses and returns the inner content object
  */
 export function extractContent(data: Descriptor | Item) {
   let output = data;

--- a/packages/content/test/index.spec.ts
+++ b/packages/content/test/index.spec.ts
@@ -81,28 +81,6 @@ describe('Engine Client', () => {
       });
     });
 
-    describe('getDescriptor', () => {
-      // Tests the contentStore getDescriptor method. Checks that it returns the index descriptor of the site editorial.
-      it('return the index descriptor', (done) => {
-        nock(baseUrl)
-          .get(endpoints.GET_DESCRIPTOR)
-          .query({
-            crafterSite,
-            flatten: false,
-            url: '/site/website/index.xml'
-          })
-          .reply(200, descriptor);
-
-        ContentStoreService.getDescriptor('/site/website/index.xml').subscribe(
-          (respDescriptor) => {
-            expect(respDescriptor).to.not.be.null;
-            expect(respDescriptor.page.objectId).to.equal(descriptor.page.objectId);
-            done();
-          }
-        );
-      });
-    });
-
     describe('getChildren', () => {
       // Tests the contentStore getChildren method. Checks that it returns the children of the index page of the site editorial.
       // The children length at its ids should match the expected values.

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/ice",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS in-context editing library",
   "main": "./bundles/ice.umd.js",
   "module": "./esm5/ice.js",
@@ -40,7 +40,7 @@
     "terser": "^5.30.1"
   },
   "dependencies": {
-    "@craftercms/models": "0.0.0-PLACEHOLDER"
+    "@craftercms/models": "5.0.0"
   },
   "peerDependencies": {
     "react": "^18.0.0"

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/models",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS data model definitions",
   "main": "./bundles/models.umd.js",
   "module": "./esm5/models.js",

--- a/packages/models/src/CrafterConfig.ts
+++ b/packages/models/src/CrafterConfig.ts
@@ -28,6 +28,7 @@ export interface CrafterConfig {
   contentTypeRegistry?: LookupTable;
   // TODO: Remove this in favour of fetchConfig.headers? Most make all sdk service use fetch.
   headers: LookupTable;
+  flatten?: boolean;
 }
 
 export interface Endpoints {

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -116,27 +116,6 @@ path           | The item’s path in the content store |
   store.dispatch(getItem(itemUrl));
 ```
 
-### getDescriptor
-Creates an action to get the descriptor data of an Item in the content store.
-
-`getDescriptor(path: string)`
-
-| Parameters    |                |
-| ------------- |:--------------:|
-| path           | The item’s path in the content store |
-
-#### Example
-
-- Dispatch action to get the index page descriptor from the site into your store
-
-```typescript
-  import { getDescriptor } from '@craftercms/redux';
-
-  const itemUrl = '/site/website/index.xml';
-
-  store.dispatch(getDescriptor(itemUrl));
-```
-
 ### getChildren
 Creates an action to get the list of Items directly under a folder into your store.
 

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/redux",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS bindings for Redux",
   "main": "./bundles/redux.umd.js",
   "module": "./esm5/redux.js",
@@ -25,7 +25,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/content": "0.0.0-PLACEHOLDER",
+    "@craftercms/content": "5.0.0",
     "@reduxjs/toolkit": "^2.2.2",
     "redux": "^5.0.1",
     "redux-observable": "^3.0.0-rc.2",

--- a/packages/redux/src/actions/content.ts
+++ b/packages/redux/src/actions/content.ts
@@ -14,17 +14,13 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import { Descriptor, Item, NavigationItem } from '@craftercms/models';
+import { Item, NavigationItem } from '@craftercms/models';
 import { createAction } from "@reduxjs/toolkit";
 import { internal_getNav, internal_getNavBreadcrumb } from "./content_internal";
 
 export const getItem = /*#__PURE__*/ createAction<string>('GET_ITEM');
 
 export const getItemComplete = /*#__PURE__*/ createAction<{ url: string, item?: Item }>('GET_ITEM_COMPLETE');
-
-export const getDescriptor = /*#__PURE__*/ createAction<string>('GET_DESCRIPTOR');
-
-export const getDescriptorComplete = /*#__PURE__*/ createAction<{ url: string, descriptor?: Descriptor }>('GET_DESCRIPTOR_COMPLETE');
 
 export const getChildren = /*#__PURE__*/ createAction<string>('GET_CHILDREN');
 

--- a/packages/redux/src/epics/content.ts
+++ b/packages/redux/src/epics/content.ts
@@ -23,8 +23,6 @@ import { ContentStoreService, NavigationService } from '@craftercms/content';
 import {
   getItem,
   getItemComplete,
-  getDescriptor,
-  getDescriptorComplete,
   getChildren,
   getChildrenComplete,
   getTree,
@@ -49,23 +47,6 @@ export const getItemEpic =
             url: payload
           })))
         ))
-  );
-
-export const getDescriptorEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(getDescriptor.type),
-      mergeMap(({ payload }) =>
-        ContentStoreService.getDescriptor(payload)
-          .pipe(
-              map(descriptor => getDescriptorComplete({
-                descriptor,
-                url: payload
-              })),
-              catchError(() => of(getDescriptorComplete({
-                url: payload
-              })))
-          ))
-
   );
 
 export const getChildrenEpic =
@@ -134,7 +115,6 @@ export const getNavBreadcrumbEpic =
 
   export const allContentEpics = [
     getItemEpic,
-    getDescriptorEpic,
     getChildrenEpic,
     getTreeEpic,
     getNavEpic,

--- a/packages/redux/src/reducers/content.ts
+++ b/packages/redux/src/reducers/content.ts
@@ -20,8 +20,6 @@ import { flattenEntries } from '../utils';
 import {
   getItem,
   getItemComplete,
-  getDescriptor,
-  getDescriptorComplete,
   getChildren,
   getChildrenComplete,
   getTree,
@@ -57,39 +55,6 @@ export function itemsReducer(state = {
         entries: {
           ...state.entries,
           [url]: item
-        }
-      }
-    }
-    default:
-      return state
-  }
-}
-
-export function descriptorsReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {}
-}, action: AnyAction): StateContainer<Item> {
-  switch (action.type) {
-    case getDescriptor.type: {
-      return {
-        ...state,
-        loading: {
-          ...state.loading,
-          [action.payload]: true
-        }
-      }
-    }
-    case getDescriptorComplete.type: {
-      const { descriptor, url } = action.payload;
-      return {
-        ...state,
-        loading: {
-          ...state.loading,
-          [url]: false
-        },
-        entries: {
-          ...state.entries,
-          [url]: descriptor
         }
       }
     }

--- a/packages/redux/src/reducers/reducers.ts
+++ b/packages/redux/src/reducers/reducers.ts
@@ -18,7 +18,6 @@ import {
   itemsReducer,
   navigationReducer,
   breadcrumbsReducer,
-  descriptorsReducer,
   childrenReducer,
   treeReducer
 } from './content';
@@ -26,7 +25,6 @@ import { searchReducer } from './search'
 
 export const allReducers = {
   items: itemsReducer,
-  descriptors: descriptorsReducer,
   children: childrenReducer,
   trees: treeReducer,
   navigation: navigationReducer,

--- a/packages/redux/test/index.spec.ts
+++ b/packages/redux/test/index.spec.ts
@@ -26,10 +26,6 @@ import {
   getItemComplete,
   itemsReducer,
   getItemEpic,
-  getDescriptor,
-  getDescriptorComplete,
-  descriptorsReducer,
-  getDescriptorEpic,
   getChildren,
   getChildrenComplete,
   childrenReducer,
@@ -105,32 +101,6 @@ describe('Crafter CMS Redux', () => {
           payload: item
         };
         const action = getItemComplete(item);
-        expect(action).to.deep.equal(expectedAction);
-        done();
-      });
-    });
-
-    describe('getDescriptor Action', () => {
-      it('should return the expected GET_DESCRIPTOR action', (done) => {
-        let url = '/site/website/index.xml',
-          expectedAction = {
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          };
-        const action = getDescriptor(url);
-        expect(action).to.deep.equal(expectedAction);
-        done();
-      });
-    });
-
-    describe('getDescriptorComplete Action', () => {
-      it('should return the expected GET_DESCRIPTOR_COMPLETE action', (done) => {
-        let url: '/site/website/index.xml',
-          expectedAction = {
-            type: 'GET_DESCRIPTOR_COMPLETE',
-            payload: { descriptor, url }
-          };
-        const action = getDescriptorComplete({ descriptor, url });
         expect(action).to.deep.equal(expectedAction);
         done();
       });
@@ -295,48 +265,6 @@ describe('Crafter CMS Redux', () => {
           };
 
         let newState = itemsReducer(undefined, action);
-        expect(newState).to.deep.equal(expectedState);
-        done();
-      });
-    });
-
-    describe('getDescriptor Reducer', () => {
-      it('should return the expected GET_DESCRIPTOR reducer', (done) => {
-        let url = '/site/website/index.xml',
-          action = {
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          },
-          expectedState = {
-            loading: {
-              [url]: true
-            },
-            entries: {}
-          };
-
-        let newState = descriptorsReducer(undefined, action);
-        expect(newState).to.deep.equal(expectedState);
-        done();
-      });
-    });
-
-    describe('getDescriptorComplete Reducer', () => {
-      it('should return the expected GET_DESCRIPTOR_COMPLETE reducer', (done) => {
-        let url = '/site/website',
-          action = {
-            type: 'GET_DESCRIPTOR_COMPLETE',
-            payload: { descriptor, url }
-          },
-          expectedState = {
-            loading: {
-              [url]: false
-            },
-            entries: {
-              [url]: descriptor
-            }
-          };
-
-        let newState = descriptorsReducer(undefined, action);
         expect(newState).to.deep.equal(expectedState);
         done();
       });
@@ -552,35 +480,6 @@ describe('Crafter CMS Redux', () => {
           // expect(payload.url.url === item.url);
           // expect(payload.url.descriptorUrl === expectedResponse.payload.url);
           // expect(payload).to.deep.equal(expectedResponse.payload);
-          done();
-        });
-      });
-    });
-
-    describe('getDescriptor Epic', () => {
-      it('should return the expected GET_DESCRIPTOR epic', (done) => {
-        nock('http://localhost:8080')
-          .get('/api/1/site/content_store/descriptor.json')
-          .query({
-            crafterSite: 'editorial',
-            flatten: false,
-            url: '/site/website/index.xml'
-          })
-          .reply(200, descriptor);
-
-        let url = '/site/website/index.xml',
-          actionObs = of({
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          }),
-          expectedResponse = {
-            payload: { descriptor, url },
-            type: 'GET_DESCRIPTOR_COMPLETE'
-          };
-
-        getDescriptorEpic(actionObs).subscribe((response) => {
-          expect(response.type).to.equal(expectedResponse.type);
-          expect(response.payload.descriptor.page.objectId).to.equal(expectedResponse.payload.descriptor.page.objectId);
           done();
         });
       });

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/search",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS search service and associated tools",
   "main": "./bundles/search.umd.js",
   "module": "./esm5/search.js",
@@ -25,9 +25,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/classes": "0.0.0-PLACEHOLDER",
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/classes": "5.0.0",
+    "@craftercms/models": "5.0.0",
+    "@craftercms/utils": "5.0.0",
     "rxjs": "^7.8.1",
     "uuid": "^10.0.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/utils",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS utility and helper functions",
   "main": "./bundles/utils.umd.js",
   "module": "./esm5/utils.js",


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8053

Remove deprecated getDescriptor API and update APIs in the js-sdk #8053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new optional "flatten" property to configuration options for content retrieval, allowing more flexible data handling.

* **Bug Fixes**
  * Improved formatting and clarity in documentation.

* **Chores**
  * Removed the deprecated "getDescriptor" functionality and all related references from the platform, including documentation, actions, reducers, epics, and tests, to streamline the codebase.
  * Updated package versions to 5.0.0 across all modules for a stable release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->