### PR TITLE
[8053] Remove deprecated getDescriptor API and update APIs in the js-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # SDK Changelog
 
+## 5.0.0
+## @craftercms/content@5.0.0
+- "Get Descriptor" API removed (use getItem instead)
+- New `crafterConf.flatten` property which controls the `flatten` parameter of content services to recursively include linked content items
+
+## @craftercms/redux@5.0.0
+- "Get Descriptor" API removed (use getItem instead)
+- `getItem` action payload is now an object with `url` and optional `config` properties (previously a string URL)
+
+## @craftercms/classes@5.0.0
+- New `crafterConf.flatten` property which controls the `flatten` parameter of content services to recursively include linked content items
+
 ## 4.2.0
 * [@craftercms/redux]:
   * getTree action payload is now an object with `url` and `depth` properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - "Get Descriptor" API removed (use getItem instead)
 - `getItem` action payload is now an object with `url` and optional `config` properties (previously a string URL)
 
-## @craftercms/classes@5.0.0
+## @craftercms/classes4.4.1
 - New `crafterConf.flatten` property which controls the `flatten` parameter of content services to recursively include linked content items
 
 ## 4.2.0
@@ -53,6 +53,7 @@
 - Update Endpoints interface `ELASTICSEARCH` property to `SEARCH`.
 
 ### @craftercms/search
+
 - Remove ElasticQuery query implementation for ElasticSearch.
 - Use `Query` class instead of removed `ElasticQuery` class in `createQuery` function.
 - Update createQuery usage examples without SearchEngine parameter.
@@ -165,6 +166,7 @@
 - Adds `reportNavigation` util for SPAs to report the current URL as the app navigates.
 
 ### misc
+
 - [internal] Bumps acorn version
 
 ## 1.2.1

--- a/packages/classes/package.json
+++ b/packages/classes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/classes",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.4.1",
   "description": "Crafter CMS utility classes for developing sites and applications",
   "main": "./bundles/classes.umd.js",
   "module": "./esm5/classes.js",
@@ -25,8 +25,8 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/models": "4.3.1",
+    "@craftercms/utils": "4.3.0",
     "query-string": "^9.1.0"
   },
   "devDependencies": {

--- a/packages/classes/src/config.ts
+++ b/packages/classes/src/config.ts
@@ -34,7 +34,8 @@ const DEFAULTS: CrafterConfig = {
   },
   fetchConfig: {},
   contentTypeRegistry: {},
-  headers: {}
+  headers: {},
+  flatten: false
 };
 
 class ConfigManager {

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -87,8 +87,8 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 `parseDescriptor(response: Descriptor | Item | GraphQLResponse | Descriptor[] | Item[] | GraphQLResponse)`
 
 | Parameters    |                |
-| ------------- |:--------------:|
-| response      | The response of a getItem, getDescriptor or GraphQL fetch call |
+| ------------- |:-----------------------------------------------:|
+| response      | The response of a getItem or GraphQL fetch call |
 
 #### Returns
 
@@ -96,7 +96,7 @@ Parse a [Descriptor](../models/src/descriptor.ts), [Item](../models/src/item.ts)
 
 #### Examples
 
-- If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem, getDescriptor or GraphQL responses.
+- If you want a cleaner/parsed response, you may use `parseDescriptor` util to parse the response for you. You may use it to parse getItem or GraphQL responses.
 
 ```typescript
   import { map } from 'rxjs/operators';
@@ -181,44 +181,6 @@ Get an Item from the content store.
   
   getItem('/site/website/index.xml', { site: 'editorial' }).pipe(
     map(parseDescriptor)
-  ).subscribe((content: ContentInstance) => {
-    console.log(content);
-  });
-```
-
-### Get Descriptor
-Get the descriptor data of an Item in the content store.
-
-`getDescriptor(path: string, config?: CrafterConfig)` 
-
-| Parameters    |                |
-| ------------- |:--------------:|
-| path          | The item’s path in the content store |
-| config        | Crafter configuration. Optional. Default value in [here](../models/README.md#CrafterConfig). |
-
-#### Returns
-
-[Descriptor](../models/README.md#Descriptor) - from the content store
-
-#### Examples
-
-- Get the index page from the site:
-
-```typescript
-  import { map } from 'rxjs/operators';
-  import { getDescriptor, parseDescriptor } from '@craftercms/content';
-  import { Descriptor, ContentInstance } from '@craftercms/models';
-
-  // Example 1: Supplying config inline, Descriptor response...
-  getDescriptor('/site/website/index.xml', { site: 'editorial' }).subscribe((descriptor: Descriptor) => {
-    console.log(descriptor);
-  });
-
-  // Example 2: 
-  // - Omit config (must have configured earlier @see Usage section above)
-  // - Parse the response
-  getDescriptor('/site/website/index.xml').pipe(
-    map(parseDescriptor) // Optional. Use for a cleaner parsed response.
   ).subscribe((content: ContentInstance) => {
     console.log(content);
   });

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/content",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS services for content and navigation retrieval",
   "main": "./bundles/content.umd.js",
   "module": "./esm5/content.js",
@@ -25,9 +25,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/classes": "0.0.0-PLACEHOLDER",
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/classes": "4.4.1",
+    "@craftercms/models": "4.3.1",
+    "@craftercms/utils": "4.3.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/packages/content/src/ContentStoreService.ts
+++ b/packages/content/src/ContentStoreService.ts
@@ -16,7 +16,7 @@
 
 import { Observable } from 'rxjs';
 import { crafterConf, SDKService } from '@craftercms/classes';
-import { CrafterConfig, Descriptor, Item } from '@craftercms/models';
+import { CrafterConfig, Item } from '@craftercms/models';
 import { composeUrl } from '@craftercms/utils';
 import { map } from 'rxjs/operators';
 
@@ -29,38 +29,11 @@ export function getItem(path: string, config: Partial<CrafterConfig>): Observabl
 export function getItem(path: string, config?: Partial<CrafterConfig>): Observable<Item> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_ITEM_URL);
-  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site, flatten: Boolean(config?.flatten) }, config.headers);
 }
 
 export interface GetDescriptorConfig extends CrafterConfig {
   flatten: boolean;
-}
-
-/**
- * Returns the descriptor data of an Item in the content store.
- * @param {string} path - The item’s path
- * @param {CrafterConfig & GetDescriptorConfig} config? - The config override options to use
- */
-export function getDescriptor(path: string): Observable<Descriptor>;
-export function getDescriptor(path: string, config: Partial<GetDescriptorConfig>): Observable<Descriptor>;
-export function getDescriptor(path: string, config?: Partial<GetDescriptorConfig>): Observable<Descriptor> {
-  let cfg = crafterConf.mix(config);
-  return SDKService.httpGet<Descriptor>(composeUrl(cfg, cfg.endpoints.GET_DESCRIPTOR), {
-    url: path,
-    crafterSite: cfg.site,
-    flatten: Boolean(config?.flatten)
-  }, cfg.headers).pipe(
-    // Manually introduce the path into the response as descriptor endpoint does not return it.
-    map((descriptor: Descriptor) => {
-      let prop = typeof descriptor.page === 'undefined' ? 'component' : 'page';
-      return {
-        [prop]: {
-          ...descriptor[prop],
-          localId: path
-        }
-      };
-    })
-  );
 }
 
 /**
@@ -72,7 +45,7 @@ export function getChildren(path: string, config: Partial<CrafterConfig>): Obser
 export function getChildren(path: string, config?: Partial<CrafterConfig>): Observable<Item[]> {
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_CHILDREN);
-  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(requestURL, { url: path, crafterSite: config.site, flatten: Boolean(config?.flatten) }, config.headers);
 }
 
 /**
@@ -91,12 +64,11 @@ export function getTree(path: string, depth: number | Partial<CrafterConfig> = 1
   }
   config = crafterConf.mix(config);
   const requestURL = composeUrl(config, config.endpoints.GET_TREE);
-  return SDKService.httpGet(requestURL, { url: path, depth, crafterSite: config.site }, config.headers);
+  return SDKService.httpGet(requestURL, { url: path, depth, crafterSite: config.site, flatten: Boolean(config?.flatten) }, config.headers);
 }
 
 export const ContentStoreService = {
   getItem,
-  getDescriptor,
   getChildren,
   getTree
 };

--- a/packages/content/src/utils.ts
+++ b/packages/content/src/utils.ts
@@ -14,9 +14,9 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import { ContentInstance, Descriptor, DescriptorResponse, Item } from '@craftercms/models';
+import type { ContentInstance, CrafterConfig, Descriptor, DescriptorResponse, Item } from '@craftercms/models';
 import { urlTransform } from './UrlTransformationService';
-import { getDescriptor, GetDescriptorConfig } from './ContentStoreService';
+import { getItem } from './ContentStoreService';
 import { map, switchMap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
@@ -92,7 +92,7 @@ export function parseDescriptor(
       '[parseDescriptor] Invalid descriptor supplied. Did you call ' +
       'parseDescriptor with a `getChildren` API response? The `getChildren` API ' +
       'response may contain certain items that are not parsable into ContentInstances. ' +
-      'Try a different API (getItem, getDescriptor or getTree) or filter out the metadata ' +
+      'Try a different API (getItem or getTree) or filter out the metadata ' +
       'items which descriptorDom property has a `page` or `component` property with the content item.'
     );
   }
@@ -210,32 +210,32 @@ export function parseFieldValue(propName: string, propValue: any): number | stri
 }
 
 export function fetchModelByPath(path: string): Observable<ContentInstance>;
-export function fetchModelByPath(path: string, options: Partial<GetDescriptorConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
+export function fetchModelByPath(path: string, options: Partial<CrafterConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
 export function fetchModelByPath(
   path: string,
-  options?: Partial<GetDescriptorConfig & ParseDescriptorOptions>
+  options?: Partial<CrafterConfig & ParseDescriptorOptions>
 ): Observable<ContentInstance> {
   let pdo = mixParseDescriptorOptions({ parseFieldValueTypes: true, ...options });
-  return getDescriptor(path, { flatten: true, ...options }).pipe(
-    map((descriptor) => parseDescriptor(descriptor, pdo))
+  return getItem(path, { flatten: true, ...options }).pipe(
+    map(({ descriptorDom }) => parseDescriptor(descriptorDom, pdo))
   );
 }
 
 export function fetchModelByUrl(webUrl: string): Observable<ContentInstance>;
-export function fetchModelByUrl(webUrl: string, options: Partial<GetDescriptorConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
+export function fetchModelByUrl(webUrl: string, options: Partial<CrafterConfig & ParseDescriptorOptions>): Observable<ContentInstance>;
 export function fetchModelByUrl(
   webUrl: string,
-  options?: Partial<GetDescriptorConfig & ParseDescriptorOptions>
+  options?: Partial<CrafterConfig & ParseDescriptorOptions>
 ): Observable<ContentInstance> {
   let pdo = mixParseDescriptorOptions({ parseFieldValueTypes: true, ...options });
   return urlTransform('renderUrlToStoreUrl', webUrl).pipe(
-    switchMap((path) => getDescriptor(path as string, { flatten: true, ...options })),
-    map((descriptor) => parseDescriptor(descriptor, pdo))
+    switchMap((path) => getItem(path as string, { flatten: true, ...options })),
+    map(({ descriptorDom }) => parseDescriptor(descriptorDom, pdo))
   );
 }
 
 /**
- * Inspects the data for getItem or getDescriptor responses and returns the inner content object
+ * Inspects the data for getItem responses and returns the inner content object
  */
 export function extractContent(data: Descriptor | Item) {
   let output = data;

--- a/packages/content/test/index.spec.ts
+++ b/packages/content/test/index.spec.ts
@@ -81,28 +81,6 @@ describe('Engine Client', () => {
       });
     });
 
-    describe('getDescriptor', () => {
-      // Tests the contentStore getDescriptor method. Checks that it returns the index descriptor of the site editorial.
-      it('return the index descriptor', (done) => {
-        nock(baseUrl)
-          .get(endpoints.GET_DESCRIPTOR)
-          .query({
-            crafterSite,
-            flatten: false,
-            url: '/site/website/index.xml'
-          })
-          .reply(200, descriptor);
-
-        ContentStoreService.getDescriptor('/site/website/index.xml').subscribe(
-          (respDescriptor) => {
-            expect(respDescriptor).to.not.be.null;
-            expect(respDescriptor.page.objectId).to.equal(descriptor.page.objectId);
-            done();
-          }
-        );
-      });
-    });
-
     describe('getChildren', () => {
       // Tests the contentStore getChildren method. Checks that it returns the children of the index page of the site editorial.
       // The children length at its ids should match the expected values.

--- a/packages/content/test/index.spec.ts
+++ b/packages/content/test/index.spec.ts
@@ -64,7 +64,8 @@ describe('Engine Client', () => {
           .get(endpoints.GET_ITEM_URL)
           .query({
             crafterSite,
-            url: '/site/website/index.xml'
+            url: '/site/website/index.xml',
+            flatten: false
           })
           .reply(200, item);
 
@@ -89,7 +90,8 @@ describe('Engine Client', () => {
           .get(endpoints.GET_CHILDREN)
           .query({
             crafterSite,
-            url: '/site/website/'
+            url: '/site/website/',
+            flatten: false
           })
           .reply(200, children);
 
@@ -111,7 +113,8 @@ describe('Engine Client', () => {
           .query({
             crafterSite,
             depth: 3,
-            url: '/site/website/articles/2021'
+            url: '/site/website/articles/2021',
+            flatten: false
           })
           .reply(200, tree);
 

--- a/packages/ice/package.json
+++ b/packages/ice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/ice",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.0",
   "description": "Crafter CMS in-context editing library",
   "main": "./bundles/ice.umd.js",
   "module": "./esm5/ice.js",

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/models",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.1",
   "description": "Crafter CMS data model definitions",
   "main": "./bundles/models.umd.js",
   "module": "./esm5/models.js",

--- a/packages/models/src/CrafterConfig.ts
+++ b/packages/models/src/CrafterConfig.ts
@@ -28,6 +28,7 @@ export interface CrafterConfig {
   contentTypeRegistry?: LookupTable;
   // TODO: Remove this in favour of fetchConfig.headers? Most make all sdk service use fetch.
   headers: LookupTable;
+  flatten: boolean;
 }
 
 export interface Endpoints {

--- a/packages/redux/README.md
+++ b/packages/redux/README.md
@@ -116,27 +116,6 @@ path           | The item’s path in the content store |
   store.dispatch(getItem(itemUrl));
 ```
 
-### getDescriptor
-Creates an action to get the descriptor data of an Item in the content store.
-
-`getDescriptor(path: string)`
-
-| Parameters    |                |
-| ------------- |:--------------:|
-| path           | The item’s path in the content store |
-
-#### Example
-
-- Dispatch action to get the index page descriptor from the site into your store
-
-```typescript
-  import { getDescriptor } from '@craftercms/redux';
-
-  const itemUrl = '/site/website/index.xml';
-
-  store.dispatch(getDescriptor(itemUrl));
-```
-
 ### getChildren
 Creates an action to get the list of Items directly under a folder into your store.
 

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/redux",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "5.0.0",
   "description": "Crafter CMS bindings for Redux",
   "main": "./bundles/redux.umd.js",
   "module": "./esm5/redux.js",
@@ -25,7 +25,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/content": "0.0.0-PLACEHOLDER",
+    "@craftercms/content": "5.0.0",
     "@reduxjs/toolkit": "^2.2.2",
     "redux": "^5.0.1",
     "redux-observable": "^3.0.0-rc.2",

--- a/packages/redux/src/actions/content.ts
+++ b/packages/redux/src/actions/content.ts
@@ -14,17 +14,13 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-import { Descriptor, Item, NavigationItem } from '@craftercms/models';
+import { CrafterConfig, Item, NavigationItem } from '@craftercms/models';
 import { createAction } from "@reduxjs/toolkit";
 import { internal_getNav, internal_getNavBreadcrumb } from "./content_internal";
 
-export const getItem = /*#__PURE__*/ createAction<string>('GET_ITEM');
+export const getItem = /*#__PURE__*/ createAction<{ url: string, config?: CrafterConfig }>('GET_ITEM');
 
 export const getItemComplete = /*#__PURE__*/ createAction<{ url: string, item?: Item }>('GET_ITEM_COMPLETE');
-
-export const getDescriptor = /*#__PURE__*/ createAction<string>('GET_DESCRIPTOR');
-
-export const getDescriptorComplete = /*#__PURE__*/ createAction<{ url: string, descriptor?: Descriptor }>('GET_DESCRIPTOR_COMPLETE');
 
 export const getChildren = /*#__PURE__*/ createAction<string>('GET_CHILDREN');
 

--- a/packages/redux/src/actions/search.ts
+++ b/packages/redux/src/actions/search.ts
@@ -19,6 +19,6 @@ import { createAction } from "@reduxjs/toolkit";
 
 export const SEARCH_COMPLETE = 'CRAFTERCMS_SEARCH_COMPLETE';
 
-export const search = /*#__PURE__*/ createAction<Query>('GET_ITEM');
+export const search = /*#__PURE__*/ createAction<Query>('CRAFTERCMS_SEACH');
 
 export const searchComplete = /*#__PURE__*/ createAction<{ queryId: string, response? }>(SEARCH_COMPLETE);

--- a/packages/redux/src/actions/search.ts
+++ b/packages/redux/src/actions/search.ts
@@ -15,10 +15,10 @@
  */
 
 import { Query } from '@craftercms/search';
-import { createAction } from "@reduxjs/toolkit";
+import { createAction } from '@reduxjs/toolkit';
 
 export const SEARCH_COMPLETE = 'CRAFTERCMS_SEARCH_COMPLETE';
 
-export const search = /*#__PURE__*/ createAction<Query>('CRAFTERCMS_SEACH');
+export const search = /*#__PURE__*/ createAction<Query>('CRAFTERCMS_SEARCH');
 
-export const searchComplete = /*#__PURE__*/ createAction<{ queryId: string, response? }>(SEARCH_COMPLETE);
+export const searchComplete = /*#__PURE__*/ createAction<{ queryId: string; response? }>(SEARCH_COMPLETE);

--- a/packages/redux/src/epics/content.ts
+++ b/packages/redux/src/epics/content.ts
@@ -23,8 +23,6 @@ import { ContentStoreService, NavigationService } from '@craftercms/content';
 import {
   getItem,
   getItemComplete,
-  getDescriptor,
-  getDescriptorComplete,
   getChildren,
   getChildrenComplete,
   getTree,
@@ -39,33 +37,16 @@ export const getItemEpic =
   (action$: Observable<AnyAction>) => action$.pipe(
     ofType(getItem.type),
     mergeMap(({ payload }) =>
-      ContentStoreService.getItem(payload)
+      ContentStoreService.getItem(payload.url, payload.config)
         .pipe(
           map((item: Item) => getItemComplete({
             item,
-            url: payload
+            url: payload.url
           })),
           catchError(() => of(getItemComplete({
-            url: payload
+            url: payload.url
           })))
         ))
-  );
-
-export const getDescriptorEpic =
-  (action$: Observable<AnyAction>) => action$.pipe(
-      ofType(getDescriptor.type),
-      mergeMap(({ payload }) =>
-        ContentStoreService.getDescriptor(payload)
-          .pipe(
-              map(descriptor => getDescriptorComplete({
-                descriptor,
-                url: payload
-              })),
-              catchError(() => of(getDescriptorComplete({
-                url: payload
-              })))
-          ))
-
   );
 
 export const getChildrenEpic =
@@ -134,7 +115,6 @@ export const getNavBreadcrumbEpic =
 
   export const allContentEpics = [
     getItemEpic,
-    getDescriptorEpic,
     getChildrenEpic,
     getTreeEpic,
     getNavEpic,

--- a/packages/redux/src/reducers/content.ts
+++ b/packages/redux/src/reducers/content.ts
@@ -20,8 +20,6 @@ import { flattenEntries } from '../utils';
 import {
   getItem,
   getItemComplete,
-  getDescriptor,
-  getDescriptorComplete,
   getChildren,
   getChildrenComplete,
   getTree,
@@ -42,7 +40,7 @@ export function itemsReducer(state = {
         ...state,
         loading: {
           ...state.loading,
-          [action.payload]: true
+          [action.payload.url]: true
         }
       }
     }
@@ -57,39 +55,6 @@ export function itemsReducer(state = {
         entries: {
           ...state.entries,
           [url]: item
-        }
-      }
-    }
-    default:
-      return state
-  }
-}
-
-export function descriptorsReducer(state = {
-  loading: {}, // { all: boolean, [id: string]: boolean }
-  entries: {}
-}, action: AnyAction): StateContainer<Item> {
-  switch (action.type) {
-    case getDescriptor.type: {
-      return {
-        ...state,
-        loading: {
-          ...state.loading,
-          [action.payload]: true
-        }
-      }
-    }
-    case getDescriptorComplete.type: {
-      const { descriptor, url } = action.payload;
-      return {
-        ...state,
-        loading: {
-          ...state.loading,
-          [url]: false
-        },
-        entries: {
-          ...state.entries,
-          [url]: descriptor
         }
       }
     }

--- a/packages/redux/src/reducers/reducers.ts
+++ b/packages/redux/src/reducers/reducers.ts
@@ -18,7 +18,6 @@ import {
   itemsReducer,
   navigationReducer,
   breadcrumbsReducer,
-  descriptorsReducer,
   childrenReducer,
   treeReducer
 } from './content';
@@ -26,7 +25,6 @@ import { searchReducer } from './search'
 
 export const allReducers = {
   items: itemsReducer,
-  descriptors: descriptorsReducer,
   children: childrenReducer,
   trees: treeReducer,
   navigation: navigationReducer,

--- a/packages/redux/test/index.spec.ts
+++ b/packages/redux/test/index.spec.ts
@@ -26,8 +26,6 @@ import {
   getItemComplete,
   itemsReducer,
   getItemEpic,
-  getDescriptor,
-  getDescriptorComplete,
   descriptorsReducer,
   getDescriptorEpic,
   getChildren,
@@ -105,32 +103,6 @@ describe('Crafter CMS Redux', () => {
           payload: item
         };
         const action = getItemComplete(item);
-        expect(action).to.deep.equal(expectedAction);
-        done();
-      });
-    });
-
-    describe('getDescriptor Action', () => {
-      it('should return the expected GET_DESCRIPTOR action', (done) => {
-        let url = '/site/website/index.xml',
-          expectedAction = {
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          };
-        const action = getDescriptor(url);
-        expect(action).to.deep.equal(expectedAction);
-        done();
-      });
-    });
-
-    describe('getDescriptorComplete Action', () => {
-      it('should return the expected GET_DESCRIPTOR_COMPLETE action', (done) => {
-        let url: '/site/website/index.xml',
-          expectedAction = {
-            type: 'GET_DESCRIPTOR_COMPLETE',
-            payload: { descriptor, url }
-          };
-        const action = getDescriptorComplete({ descriptor, url });
         expect(action).to.deep.equal(expectedAction);
         done();
       });
@@ -295,48 +267,6 @@ describe('Crafter CMS Redux', () => {
           };
 
         let newState = itemsReducer(undefined, action);
-        expect(newState).to.deep.equal(expectedState);
-        done();
-      });
-    });
-
-    describe('getDescriptor Reducer', () => {
-      it('should return the expected GET_DESCRIPTOR reducer', (done) => {
-        let url = '/site/website/index.xml',
-          action = {
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          },
-          expectedState = {
-            loading: {
-              [url]: true
-            },
-            entries: {}
-          };
-
-        let newState = descriptorsReducer(undefined, action);
-        expect(newState).to.deep.equal(expectedState);
-        done();
-      });
-    });
-
-    describe('getDescriptorComplete Reducer', () => {
-      it('should return the expected GET_DESCRIPTOR_COMPLETE reducer', (done) => {
-        let url = '/site/website',
-          action = {
-            type: 'GET_DESCRIPTOR_COMPLETE',
-            payload: { descriptor, url }
-          },
-          expectedState = {
-            loading: {
-              [url]: false
-            },
-            entries: {
-              [url]: descriptor
-            }
-          };
-
-        let newState = descriptorsReducer(undefined, action);
         expect(newState).to.deep.equal(expectedState);
         done();
       });
@@ -552,35 +482,6 @@ describe('Crafter CMS Redux', () => {
           // expect(payload.url.url === item.url);
           // expect(payload.url.descriptorUrl === expectedResponse.payload.url);
           // expect(payload).to.deep.equal(expectedResponse.payload);
-          done();
-        });
-      });
-    });
-
-    describe('getDescriptor Epic', () => {
-      it('should return the expected GET_DESCRIPTOR epic', (done) => {
-        nock('http://localhost:8080')
-          .get('/api/1/site/content_store/descriptor.json')
-          .query({
-            crafterSite: 'editorial',
-            flatten: false,
-            url: '/site/website/index.xml'
-          })
-          .reply(200, descriptor);
-
-        let url = '/site/website/index.xml',
-          actionObs = of({
-            type: 'GET_DESCRIPTOR',
-            payload: url
-          }),
-          expectedResponse = {
-            payload: { descriptor, url },
-            type: 'GET_DESCRIPTOR_COMPLETE'
-          };
-
-        getDescriptorEpic(actionObs).subscribe((response) => {
-          expect(response.type).to.equal(expectedResponse.type);
-          expect(response.payload.descriptor.page.objectId).to.equal(expectedResponse.payload.descriptor.page.objectId);
           done();
         });
       });

--- a/packages/redux/test/index.spec.ts
+++ b/packages/redux/test/index.spec.ts
@@ -86,9 +86,9 @@ describe('Crafter CMS Redux', () => {
         let url = '/site/website/index.xml',
           expectedAction = {
             type: 'GET_ITEM',
-            payload: url
+            payload: { url }
           };
-        const action = getItem(url);
+        const action = getItem({ url });
         expect(action).to.deep.equal(expectedAction);
         done();
       });
@@ -231,7 +231,7 @@ describe('Crafter CMS Redux', () => {
         let url = '/site/website/index.xml',
           action = {
             type: 'GET_ITEM',
-            payload: url
+            payload: { url }
           },
           expectedState = {
             loading: {
@@ -458,14 +458,15 @@ describe('Crafter CMS Redux', () => {
           .get('/api/1/site/content_store/item.json')
           .query({
             crafterSite: 'editorial',
-            url: '/site/website/index.xml'
+            url: '/site/website/index.xml',
+            flatten: false
           })
           .reply(200, item);
 
         let url = '/site/website/index.xml',
           actionObs = of({
             type: 'GET_ITEM',
-            payload: url
+            payload: { url }
           }),
           expectedResponse = {
             payload: {
@@ -491,7 +492,8 @@ describe('Crafter CMS Redux', () => {
           .get('/api/1/site/content_store/children.json')
           .query({
             crafterSite: 'editorial',
-            url: '/site/website'
+            url: '/site/website',
+            flatten: false
           })
           .reply(200, children);
 
@@ -519,7 +521,8 @@ describe('Crafter CMS Redux', () => {
           .query({
             crafterSite: 'editorial',
             depth: 1,
-            url: '/site/website'
+            url: '/site/website',
+            flatten: false
           })
           .reply(200, tree);
 

--- a/packages/redux/test/index.spec.ts
+++ b/packages/redux/test/index.spec.ts
@@ -26,8 +26,6 @@ import {
   getItemComplete,
   itemsReducer,
   getItemEpic,
-  descriptorsReducer,
-  getDescriptorEpic,
   getChildren,
   getChildrenComplete,
   childrenReducer,

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/search",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.1",
   "description": "Crafter CMS search service and associated tools",
   "main": "./bundles/search.umd.js",
   "module": "./esm5/search.js",
@@ -25,9 +25,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@craftercms/classes": "0.0.0-PLACEHOLDER",
-    "@craftercms/models": "0.0.0-PLACEHOLDER",
-    "@craftercms/utils": "0.0.0-PLACEHOLDER",
+    "@craftercms/classes": "4.4.1",
+    "@craftercms/models": "4.3.1",
+    "@craftercms/utils": "4.3.0",
     "rxjs": "^7.8.1",
     "uuid": "^10.0.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@craftercms/utils",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "4.3.0",
   "description": "Crafter CMS utility and helper functions",
   "main": "./bundles/utils.umd.js",
   "module": "./esm5/utils.js",


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `flatten` option for content retrieval and configuration, enabling flattened results from item/tree/children requests.
* **Bug Fixes**
  * Updated item-loading and Redux state handling to consistently key loading by the requested item URL.
* **Breaking Changes**
  * Removed the “Get Descriptor” API surface from the content store and Redux descriptor actions; use item-based retrieval instead.
  * Updated item fetch action payload to accept `{ url, config }`.
* **Documentation**
  * Refreshed content service documentation to reflect item-based APIs and `flatten`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->